### PR TITLE
Docs: say what to do when MiniMax Creator is still installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,33 @@ cd ComfyUI/custom_nodes
 git clone https://github.com/roadmaus/ComfyUI-Continuity
 ```
 
-Restart ComfyUI. Nothing to pip install.
+That leaves one folder, `ComfyUI-Continuity`, inside `custom_nodes/`. Restart
+ComfyUI. Nothing to pip install.
+
+### Already have MiniMax Creator installed
+
+Read this one before you clone. This pack used to be called MiniMax Creator,
+and the rename left the node ids alone, so the old folder and a fresh clone are
+two packs claiming the same nodes. ComfyUI refuses at least one of them over
+that, and the symptom people report is worse than the wrong one winning:
+nothing shows up at all — no Continuity in the node search, no MiniMax Creator
+either — with a duplicate-node complaint buried in the startup console.
+
+So keep one copy. The old clone is already this repo behind a redirect, so the
+shortest fix is to update it where it stands:
+
+```
+cd ComfyUI/custom_nodes/ComfyUI-MiniMax-Creator
+git remote set-url origin https://github.com/roadmaus/ComfyUI-Continuity.git
+git pull
+```
+
+The folder name is nothing to ComfyUI; rename it or don't. If you would rather
+clone fresh, delete the old folder first — your presets, settings, favourites
+and LoRA memory are in ComfyUI's `user/` directory, not in the pack, and the
+new install reads them under their old names. If MiniMax Creator came from the
+ComfyUI Manager rather than a `git clone`, uninstall it there instead of
+deleting the folder by hand.
 
 ## Documentation
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,6 +23,24 @@ The gear on the node's rail opens the pack's settings.
 
 ## Common errors
 
+### I installed Continuity and now no node shows up at all
+
+Look in `ComfyUI/custom_nodes` for a second copy of this pack — usually
+`ComfyUI-MiniMax-Creator` beside a fresh `ComfyUI-Continuity`. The rename left
+the node ids alone, on purpose, so that saved workflows kept loading; the cost
+is that two folders of this pack are two packs registering the same node ids.
+ComfyUI refuses at least one of them over that, and what people report is
+neither name reaching the node search. The startup console log says so,
+somewhere above wherever you are looking.
+
+Delete one of them and restart. Which one doesn't matter much: the old clone
+pulls this repo through GitHub's redirect, so `git remote set-url origin
+https://github.com/roadmaus/ComfyUI-Continuity.git && git pull` inside it is a
+complete install under an old folder name, and the folder name means nothing to
+ComfyUI. Nothing you have made is in either folder — presets, settings,
+favourites and LoRA memory sit in ComfyUI's `user/` directory. If the copy you
+want gone came from the ComfyUI Manager, uninstall it there.
+
 ### "Render refused, naming a field and a folder"
 
 Not a bug: a weight file is missing. Put the file it names in the folder it

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,25 @@ cd ComfyUI/custom_nodes
 git clone https://github.com/roadmaus/ComfyUI-Continuity
 ```
 
-Restart ComfyUI.
+That leaves one folder, `ComfyUI-Continuity`, inside `custom_nodes/`. Restart
+ComfyUI.
+
+**If you already have MiniMax Creator installed, don't clone alongside it.**
+This pack used to be called MiniMax Creator and kept its node ids through the
+rename, so the old folder and a new clone are two packs claiming the same
+nodes — and what people report is not one of them winning, it is neither of
+them appearing. Update the old clone in place instead:
+
+```
+cd ComfyUI/custom_nodes/ComfyUI-MiniMax-Creator
+git remote set-url origin https://github.com/roadmaus/ComfyUI-Continuity.git
+git pull
+```
+
+Or delete the old folder and then clone. Nothing you have made is inside it —
+presets, settings and favourites live in ComfyUI's `user/` directory and are
+read back under their old names. If the old copy came from the ComfyUI
+Manager, uninstall it there rather than deleting the folder.
 
 ## Download one family's weights
 


### PR DESCRIPTION
A user reported that after cloning this repo the node did not appear at
all — not under either name — until they deleted their old
ComfyUI-MiniMax-Creator folder. The rename deliberately kept the node
ids so saved workflows would keep loading, which means two folders of
this pack are two packs registering the same ids, and the install line
never said so: it reads as "clone it" whether or not you already have
the pack.

README and getting-started now name the resulting folder, and both carry
the case before the clone: update the old clone in place through the
GitHub redirect, or delete it first, and nothing user-made is lost
either way because presets and settings live in ComfyUI's user/
directory. The FAQ gets the symptom as a Common errors entry, filed
under what someone with no visible node would actually search for.