### PR TITLE
Docs: pull, don't clone, when coming from MiniMax Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,23 @@ ComfyUI. Nothing to pip install.
 
 ### Already have MiniMax Creator installed
 
-Read this one before you clone. This pack used to be called MiniMax Creator,
-and the rename left the node ids alone, so the old folder and a fresh clone are
-two packs claiming the same nodes. ComfyUI refuses at least one of them over
-that, and the symptom people report is worse than the wrong one winning:
-nothing shows up at all — no Continuity in the node search, no MiniMax Creator
-either — with a duplicate-node complaint buried in the startup console.
-
-So keep one copy. The old clone is already this repo behind a redirect, so the
-shortest fix is to update it where it stands:
+Don't clone. This pack was renamed, and GitHub redirects the old address here,
+so a pull in the folder you already have is the whole update:
 
 ```
 cd ComfyUI/custom_nodes/ComfyUI-MiniMax-Creator
-git remote set-url origin https://github.com/roadmaus/ComfyUI-Continuity.git
 git pull
 ```
 
-The folder name is nothing to ComfyUI; rename it or don't. If you would rather
-clone fresh, delete the old folder first — your presets, settings, favourites
-and LoRA memory are in ComfyUI's `user/` directory, not in the pack, and the
-new install reads them under their old names. If MiniMax Creator came from the
-ComfyUI Manager rather than a `git clone`, uninstall it there instead of
-deleting the folder by hand.
+The folder name doesn't matter to ComfyUI, so rename it or leave it. If it came
+from the Manager, update it there as usual.
+
+Cloning next to the old folder is what breaks. The node ids stayed the same
+through the rename so that old workflows keep loading, so two folders are two
+packs registering the same ids, and the result is no node in the search at all,
+under either name. If you already have both, delete one and restart. Your
+presets, settings, favourites and LoRA memory are in ComfyUI's `user/`
+directory, not in the pack folder.
 
 ## Documentation
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,10 +15,10 @@ The gear on the node's rail opens the pack's settings.
   `web/creator/locales/`.
 - **Appearance** has a text size, and the pack takes its colours from
   ComfyUI's palette.
-- **Stored data** lists everything the pack has written down — the preset
-  library scope by scope, the stars and the LoRA notes this browser holds, the
-  reference cache, the refiner's server, and the settings themselves — with a
-  count beside each one and a press to remove it. Nothing there deletes a
+- **Stored data** lists everything the pack has written down, with a count
+  beside each one and a press to remove it: the preset library scope by scope,
+  the stars and the LoRA notes this browser holds, the reference cache, the
+  refiner's server, and the settings themselves. Nothing there deletes a
   render, a reference or a workflow: those are files.
 
 ## Common errors

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,21 +25,19 @@ The gear on the node's rail opens the pack's settings.
 
 ### I installed Continuity and now no node shows up at all
 
-Look in `ComfyUI/custom_nodes` for a second copy of this pack — usually
-`ComfyUI-MiniMax-Creator` beside a fresh `ComfyUI-Continuity`. The rename left
-the node ids alone, on purpose, so that saved workflows kept loading; the cost
-is that two folders of this pack are two packs registering the same node ids.
-ComfyUI refuses at least one of them over that, and what people report is
-neither name reaching the node search. The startup console log says so,
-somewhere above wherever you are looking.
+Look in `ComfyUI/custom_nodes` for a second copy of this pack, usually
+`ComfyUI-MiniMax-Creator` sitting beside a fresh `ComfyUI-Continuity`. The node
+ids stayed the same through the rename, on purpose, so that saved workflows
+kept loading. The cost is that two folders of this pack are two packs
+registering the same ids, and you end up with neither in the node search. The
+startup console log says so, somewhere above wherever you are looking.
 
-Delete one of them and restart. Which one doesn't matter much: the old clone
-pulls this repo through GitHub's redirect, so `git remote set-url origin
-https://github.com/roadmaus/ComfyUI-Continuity.git && git pull` inside it is a
-complete install under an old folder name, and the folder name means nothing to
-ComfyUI. Nothing you have made is in either folder — presets, settings,
-favourites and LoRA memory sit in ComfyUI's `user/` directory. If the copy you
-want gone came from the ComfyUI Manager, uninstall it there.
+Delete one of them and restart. Which one is up to you: the old address
+redirects here, so a `git pull` in the MiniMax Creator folder leaves you fully
+up to date under an old folder name, and the name means nothing to ComfyUI.
+Nothing you made is in either folder, since presets, settings, favourites and
+LoRA memory sit in ComfyUI's `user/` directory. If the copy you want gone came
+from the ComfyUI Manager, uninstall it there.
 
 ### "Render refused, naming a field and a folder"
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,22 +18,13 @@ git clone https://github.com/roadmaus/ComfyUI-Continuity
 That leaves one folder, `ComfyUI-Continuity`, inside `custom_nodes/`. Restart
 ComfyUI.
 
-**If you already have MiniMax Creator installed, don't clone alongside it.**
-This pack used to be called MiniMax Creator and kept its node ids through the
-rename, so the old folder and a new clone are two packs claiming the same
-nodes — and what people report is not one of them winning, it is neither of
-them appearing. Update the old clone in place instead:
-
-```
-cd ComfyUI/custom_nodes/ComfyUI-MiniMax-Creator
-git remote set-url origin https://github.com/roadmaus/ComfyUI-Continuity.git
-git pull
-```
-
-Or delete the old folder and then clone. Nothing you have made is inside it —
-presets, settings and favourites live in ComfyUI's `user/` directory and are
-read back under their old names. If the old copy came from the ComfyUI
-Manager, uninstall it there rather than deleting the folder.
+**Already have MiniMax Creator installed? Pull it, don't clone.** The old
+address redirects here, so `git pull` in the folder you have is a complete
+update, whatever that folder is called. Cloning a second copy beside it is what
+breaks: the node ids stayed the same through the rename, two folders register
+the same ids, and the result is no node showing up at all. If you
+already have both, delete one and restart. Nothing you made is in either
+folder, since presets and settings live in ComfyUI's `user/` directory.
 
 ## Download one family's weights
 

--- a/docs/the-node.md
+++ b/docs/the-node.md
@@ -25,7 +25,7 @@ output folder, so a clip you just made can go straight back in as a reference.
 
 A shelf is a folder on disk and nothing else. The "+" makes the directory,
 dragging a thumbnail onto a chip moves the file into it, and the row shows what
-is actually there — so a folder you delete from a terminal is gone from the
+is actually there, so a folder you delete from a terminal is gone from the
 picker on the next listing. An empty one you made by mistake has a *Remove
 shelf* at the end of the row; a folder with anything in it is a file manager's
 job.
@@ -163,8 +163,8 @@ re-render.
 
 H3 can sample one shot across several cards, which on a pair is roughly half
 the wall clock. Install the [Raylight community
-fork](https://github.com/Karmabu/raylight) — the upstream Raylight has no H3
-path — and a **Sampling** row appears at the top of the weights popover. Pick
+fork](https://github.com/Karmabu/raylight), since the upstream Raylight has no
+H3 path, and a **Sampling** row appears at the top of the weights popover. Pick
 `Raylight · 2 GPUs` and queue as usual: the checkpoint is loaded into one Ray
 worker per card and the sequence is split across them, while the prompt is
 still encoded and the video still decoded on your own card. Preview frames keep
@@ -176,7 +176,7 @@ quietly dropped from the render:
 
 - the refine (two-pass upscale), faces and re-detail passes,
 - the turbo lead-in,
-- sound seams — a shot continuing the previous one's soundtrack,
+- sound seams, meaning a shot continuing the previous one's soundtrack,
 - ControlNet guides: they reach H3 through the conditioning, so they would
   arrive intact and then be ignored by Raylight's own forward pass,
 - every accelerator except sage attention, which Raylight runs itself,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,14 +44,14 @@ the file is in the picker either way.
 
 Starts from nothing at all: block a scene out of grey boxes, walk a camera
 through it, and render a guide along the camera's path. No model, no download,
-no queue — the renderer is arithmetic in the browser, and what is on the glass
+no queue. The renderer is arithmetic in the browser, and what is on the glass
 is exactly what gets written into `input/continuity/blockout/`.
 
 ![The blockout bench: a subject block selected with its move handles, the shot camera drawn as a frustum with its path on the floor, and the staging narrated in the foot](img/blockout.png)
 
 The floor opens bare. Add a **Block**, **Wall** or **Post**, or start from one
-of the five arrangements in the rail — Two-shot, Corridor, Interview, Street
-corner, or Bare floor — each of which brings its own camera and its own move,
+of the five arrangements in the rail (Two-shot, Corridor, Interview, Street
+corner, or Bare floor), each of which brings its own camera and its own move,
 so what lands on the glass is a shot rather than an assembly kit. Starting from
 one replaces whatever is there.
 
@@ -77,14 +77,14 @@ still instead. Pressing a mark's name puts the camera back on it.
 
 ### Editing the set
 
-Click a piece to select it. Its handles hang off it on the glass — **Move**
+Click a piece to select it. Its handles hang off it on the glass. **Move**
 (`1`) slides it along the world axes or, dragged by its body, across the floor;
 **Turn** (`2`) gives it three rings; **Size** (`3`) three square caps. `Shift+D`
 duplicates the selection, `X` removes it, and **Snap** rounds a place to 0.25 m
 or a metre and a turn to 15°. The rail carries the same numbers as figures, in
 the handles' own colours, and they stay in step with whatever the glass does.
 
-The **Frame** pill carries the same aspect popover the strip does — the shape
+The **Frame** pill carries the same aspect popover the strip does: the shape
 grid over one orientation switch, off the family's own manifest, so what is on
 offer is what the weights will accept. The pill says the pixels beside the
 ratio, because a guide is written at that family's native canvas for the shape
@@ -92,7 +92,7 @@ you pick: what the file holds is the size the render will read it at.
 
 ### What the glass shows
 
-**Stage** is the set as you handle it — clay, the grid with its five-metre
+**Stage** is the set as you handle it: clay, the grid with its five-metre
 lines and coloured world axes, the selection ring, the handles, the camera, the
 names. **Depth** (or whichever pass is selected in Output) is the frame exactly
 as the file will hold it, with no staging aids on it at all.
@@ -101,31 +101,31 @@ Four outputs, three of them wearing the ControlNet bench's own names:
 
 | Pass | What it writes |
 |---|---|
-| As staged | no tracing — the clay render itself, as footage, for the families that read a plain clip or picture as a reference or an init |
-| Depth | near bright, far dark, the map Depth Anything draws — from the geometry, so nothing is guessed |
+| As staged | no tracing, just the clay render itself, as footage, for the families that read a plain clip or picture as a reference or an init |
+| Depth | near bright, far dark, the map Depth Anything draws, taken from the geometry, so nothing is guessed |
 | Blocks | each piece one flat field of colour |
 | Lines | the set's edges, white on black |
 
 The grid, the selection ring, the handles, the camera and the names are staging
 aids: they live on the Stage view and never reach the written file.
 
-A piece can be told who or what it is. **Plays** hands it to a cast member —
-the block wears their chip hue on the stage side, never in the written file —
+A piece can be told who or what it is. **Plays** hands it to a cast member
+(the block wears their chip hue on the stage side, never in the written file),
 and **Called** gives a thing its word ("table", "doorway"). Named pieces are
 written into the staging: the bench computes who stands where in frame from
-its own projection, and the foot narrates the whole of it as you work —
+its own projection, and the foot narrates the whole of it as you work:
 *"@anna stands at centre in the midground; a table at frame left in the
-foreground. The camera pushes in toward @anna at slow speed."* — the camera
-half in the motion-type, amplitude and speed vocabulary the H3 prompt spec
+foreground. The camera pushes in toward @anna at slow speed."* The camera half
+is in the motion-type, amplitude and speed vocabulary the H3 prompt spec
 defines. **Copy** hands you the prose to paste straight into a prompt, where
 `@anna` becomes her references by the same substitution every prompt already
-does. No model reads identity out of pixels — a depth map is identity-free by
+does. No model reads identity out of pixels. A depth map is identity-free by
 construction, and even mask-injection systems bind a reference to its region
-through the prompt — which is why the words are the mechanism, and why they
-are generated rather than hand-written.
+through the prompt, which is why the words are the mechanism, and why they are
+generated rather than hand-written.
 
 The finished guide goes through the same doors a tracing does, and the scene
-itself is saved as a small `.json` beside the clip — including each named
+itself is saved as a small `.json` beside the clip, including each named
 piece's screen box at every mark, for conditioning schemes that can ground
 against layout when one arrives.
 
@@ -201,7 +201,7 @@ unchanged video.
 
 On MiniMax H3 each card also carries a **Soundtrack** dial. H3 generates picture
 and sound together through one transformer, so an adapter conditions the audio
-whether it was trained to or not — and it was: video and audio are denoised
+whether it was trained to or not. And it was: video and audio are denoised
 jointly during training, so a file built from clips whose sound was silent,
 scraped or absent has learned that too, and emits it under every render it is
 in. The usual symptom is mumbled speech in a shot where nobody was meant to


### PR DESCRIPTION
Follow-up to #39, which merged an earlier draft of the install note. Two commits.

### The note itself

A user reported that after cloning this repo the node did not show up at all, under either name, until they deleted their old `ComfyUI-MiniMax-Creator` folder. The rename deliberately froze the node ids so saved workflows would keep loading, which means two folders of this pack are two packs registering the same ids, and the install line never accounted for that: it reads as "clone it" whether or not you already have the pack.

The version that merged in #39 buried the simple answer under a `git remote set-url` step and made deleting the old folder sound mandatory. Neither is true:

- `git ls-remote https://github.com/roadmaus/ComfyUI-MiniMax-Creator.git` returns this repo's exact `main` sha, so the old address redirects and a plain `git pull` in the existing folder is a complete update.
- Nothing keys off the pack's folder name. `WEB_DIRECTORY = "./web"` is relative, and the only hardcoded pack names in `web/` and `creator/` belong to other packs, so the old folder name is fine to keep.

So the note now leads with "don't clone, pull", and keeps the delete-one-folder recovery for anyone already in the broken state. Also says that presets, settings, favourites and LoRA memory sit in ComfyUI's `user/` directory (`creator/settings.py`), so deleting a pack folder loses nothing. Three places: README install section, `docs/getting-started.md`, and a `docs/faq.md` entry filed under Common errors, since that is what someone with an invisible node will actually scan.

### De-dashing the guides

Second commit removes the 22 em dashes in `docs/faq.md`, `docs/the-node.md` and `docs/tools.md`. Rewritten sentence by sentence rather than swapping the character for a hyphen: most became a full stop or a colon, the parenthetical pairs became real parentheses. README, getting-started, families, models, timeline and docs/README had none to begin with. `CHANGELOG.md` and the JS UI strings are untouched. `15°` and the `Raylight · 2 GPUs` label are kept, being a degree sign and literal UI text.

Docs only, no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmTefpkGJcKcBk3FMCszEx)_