### PR TITLE
Keep DLSS controls usable and export held takes

### DIFF
--- a/creator/neuralpass.py
+++ b/creator/neuralpass.py
@@ -223,6 +223,11 @@ class ContinuityNeuralPass(io.ComfyNode):
         parts = list(reel or [])
         passes = [index for index, part in enumerate(parts) if "pass" in part]
         if not passes:
+            # Held takes are compiled to clips, which may already be refined.
+            # Assembling them must neither refine them twice nor require the
+            # optional weights on a machine that only wants to save the reel.
+            if parts and all("clip" in part for part in parts):
+                return io.NodeOutput(parts)
             raise RuntimeError("the neural pass was given a reel with nothing "
                                "generated on it — there is nothing to refine.")
         try:

--- a/tests/test_neural_clip_reel.py
+++ b/tests/test_neural_clip_reel.py
@@ -1,0 +1,93 @@
+"""Clip-only reels bypass optional DLSS; generated passes still refine in order.
+
+    COMFYUI_PATH=~/ComfyUI <comfy-venv>/bin/python3 tests/test_neural_clip_reel.py
+
+CPU only. The actual node executes; dependency checks and frame processing are
+spies, so no DLL, weights, server, or user media are needed.
+"""
+
+import os
+import sys
+import tempfile
+from unittest.mock import patch
+
+import layout
+from harness import check
+
+sys.path.insert(0, os.environ.get("COMFYUI_PATH", os.path.expanduser("~/ComfyUI")))
+with tempfile.TemporaryDirectory(prefix="continuity-neural-reel-") as runtime:
+    sys.argv = [__file__, "--cpu", "--base-directory", runtime]
+    import comfy.cli_args
+    comfy.cli_args.args.cpu = True
+    import folder_paths
+    for kind in ("input", "output", "temp", "user"):
+        path = os.path.join(runtime, kind)
+        os.makedirs(path)
+        getattr(folder_paths, f"set_{kind}_directory")(path)
+
+    pkg = layout.load("neuralpass")
+    neuralpass, neural = pkg.neuralpass, pkg.neural
+    node = neuralpass.ContinuityNeuralPass
+    options = dict(profile="standard", detail_strength=1.25,
+                   colour_strength=0, intensity=1, precision="fast", frame_index=7)
+    clips = [{"clip": {"filename": "held-a.mp4", "duration_s": 5}},
+             {"clip": {"filename": "supplied-b.mp4", "duration_s": 3}}]
+
+    def missing():
+        raise neural.NeuralError("test: optional weights are not installed")
+
+    with patch.object(neural, "require", side_effect=missing) as require, \
+            patch.object(neural, "release") as release:
+        try:
+            out = node.execute(clips, **options).result[0]
+        except RuntimeError as exc:
+            out = str(exc)
+        check("held/supplied clips pass through without dependencies", out, clips)
+        check("no weights check for clips", require.call_count, 0)
+        check("no pipeline touched for clips", release.call_count, 0)
+        for invalid in ([], [{"unexpected": {}}], [clips[0], {}]):
+            try:
+                node.execute(invalid, **options)
+                rejected = False
+            except RuntimeError:
+                rejected = True
+            check("empty or malformed reels remain errors", rejected, True)
+        generated = {"pass": {"frames": 2, "name": "a"}}
+        try:
+            node.execute([generated], **options)
+            error = ""
+        except RuntimeError as exc:
+            error = str(exc)
+        check("generated passes still require weights", "not installed" in error, True)
+        check("generated dependency failure releases", release.call_count, 1)
+
+    events = []
+
+    class Sequence:
+        motion = "test"
+        scene_cuts = 0
+
+        def __init__(self, request, frame_index):
+            events.append(("start", frame_index))
+
+        def reset(self):
+            events.append(("reset",))
+
+    def refine(source, sequence, tick):
+        events.append(("refine", source["name"]))
+        return {**source, "refined": True}
+
+    second = {"pass": {"frames": 3, "name": "b"}}
+    third = {"pass": {"frames": 4, "name": "c"}}
+    reel = [generated, second, clips[0], third]
+    with patch.object(neural, "require"), patch.object(neural, "release") as release, \
+            patch.object(neural, "Sequence", Sequence), \
+            patch.object(neuralpass, "_progress", return_value=lambda: None) as progress, \
+            patch.object(node, "_one", side_effect=refine):
+        out = node.execute(reel, **options).result[0]
+        check("generated pass order and reset across a clip", events,
+              [("start", 7), ("refine", "a"), ("refine", "b"), ("reset",), ("refine", "c")])
+        check("inserted clip is unchanged", out[2] is clips[0], True)
+        check("source pass is not modified", "refined" in generated["pass"], False)
+        check("only generated frames count towards progress", progress.call_args.args, (9,))
+        check("mixed reel releases once", release.call_count, 1)

--- a/tests/test_neural_popup.py
+++ b/tests/test_neural_popup.py
@@ -61,10 +61,11 @@ for (const ready of [false, true]) {
     // The body is not the modal Timeline class; do not add a fake method to
     // make its callback work. This exercises the callback actually shipped.
     assert.equal(typeof body.geometry, "undefined");
+    const beforeOpening = store.writes;
     click(pill);
     assert.ok(pop()?.isConnected);
     assert.equal(displayedOn(), String(on));
-    assert.equal(store.writes, 0, "opening settings does not save them");
+    assert.equal(store.writes, beforeOpening, "opening settings does not save them");
     if (!on) click(toggle());
     assert.equal(displayedOn(), "true");
     assert.equal(body.timeline.neural.on, true);

--- a/tests/test_neural_popup.py
+++ b/tests/test_neural_popup.py
@@ -1,0 +1,140 @@
+"""DLSS can always be switched off, including on a machine without its weights.
+
+    python3 tests/test_neural_popup.py
+
+The actual TimelineBody sampler row and shared popover run against the existing
+DOM shim. No server, GPU, DLL, or weights are needed: their absence must not
+prevent editing a saved workflow. These are interaction/serialization checks,
+not browser-layout or neural-rendering tests.
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+// Keep text assertions independent of the machine's browser/Node locale.
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const S = await import("./web/creator/state.js");
+const { NEURAL } = await import("./web/creator/manifest.js");
+const { TimelineBody } = await import("./web/creator/timeline.js");
+const { openNeuralPopover } = await import("./web/creator/pills.js");
+
+function click(node) {
+  assert.ok(node, "the click target exists");
+  for (const listener of node.listeners.click ?? []) {
+    listener({ currentTarget: node, target: node,
+               stopPropagation() {}, preventDefault() {} });
+  }
+}
+const pop = () => document.body.querySelector(".mmc-neural-pop");
+const toggle = () => pop()?.querySelector('[role="switch"]');
+const displayedOn = () => toggle()?.getAttribute("aria-checked");
+
+function build(on, ready, saved = null) {
+  document.body.replaceChildren();
+  NEURAL.ready = ready;
+  NEURAL.needs = ready ? null : "DLSS weights are absent";
+  const store = { writes: 0, value: saved ?? JSON.stringify({ version: 2,
+    aspect: "16:9", short_edge: 480,
+    segments: [{ prompt: "one", duration_s: 6 }, { prompt: "two", duration_s: 6 }],
+    neural: { ...S.emptyNeural(), on },
+  }) };
+  const body = new TimelineBody({
+    read: () => store.value,
+    write: (value) => { store.value = value; store.writes++; },
+    widgets: {}, nodeId: () => 1,
+  });
+  const row = body.renderSampling();
+  document.body.appendChild(row);
+  const pill = row.querySelectorAll("button").find((n) => n.text.includes("DLSS"));
+  return { body, store, pill };
+}
+
+let bodyCases = 0;
+for (const ready of [false, true]) {
+  for (const on of [false, true]) {
+    const { body, store, pill } = build(on, ready);
+    // The body is not the modal Timeline class; do not add a fake method to
+    // make its callback work. This exercises the callback actually shipped.
+    assert.equal(typeof body.geometry, "undefined");
+    click(pill);
+    assert.ok(pop()?.isConnected);
+    assert.equal(displayedOn(), String(on));
+    assert.equal(store.writes, 0, "opening settings does not save them");
+    if (!on) click(toggle());
+    assert.equal(displayedOn(), "true");
+    assert.equal(body.timeline.neural.on, true);
+    assert.ok(pop().text.includes("832 × 480"), "the timeline canvas supplies the estimate");
+    click(toggle());
+    assert.equal(displayedOn(), "false");
+    assert.equal(body.timeline.neural.on, false);
+    assert.equal(Object.hasOwn(JSON.parse(store.value), "neural"), false);
+    // An unrelated control must not resurrect ON when it saves the timeline.
+    body.set("cfg", 3.5);
+    assert.equal(Object.hasOwn(JSON.parse(store.value), "neural"), false);
+    const reloaded = build(false, ready, store.value);
+    assert.equal(reloaded.body.timeline.neural.on, false);
+    click(reloaded.pill);
+    assert.equal(displayedOn(), "false");
+    body.destroy();
+    reloaded.body.destroy();
+    bodyCases++;
+  }
+}
+
+let fallbackCases = 0;
+const warnings = [];
+const warn = console.warn;
+console.warn = (...args) => warnings.push(args);
+try {
+  for (const ready of [false, true]) {
+    for (const initialOn of [false, true]) {
+      const { body, store, pill } = build(initialOn, ready);
+      openNeuralPopover(pill, {
+        target: body.timeline, commit: () => body.commit(),
+        geometry: () => { throw new Error("estimate unavailable"); },
+      });
+      assert.ok(pop()?.isConnected, "optional geometry cannot prevent opening");
+      if (!initialOn) click(toggle());
+      assert.equal(displayedOn(), "true");
+      assert.equal(body.timeline.neural.on, true);
+      assert.ok(pop().text.includes("About a gigabyte of VRAM per megapixel."));
+      if (!initialOn) assert.equal(JSON.parse(store.value).neural.on, true);
+      click(toggle());
+      assert.equal(displayedOn(), "false");
+      assert.equal(body.timeline.neural.on, false);
+      assert.equal(Object.hasOwn(JSON.parse(store.value), "neural"), false);
+      assert.equal(S.parseTimeline(store.value).neural.on, false);
+      body.destroy();
+      fallbackCases++;
+    }
+  }
+} finally {
+  console.warn = warn;
+}
+assert.equal(warnings.length, 4, "only the four failed estimates are reported");
+assert.ok(warnings.every((entry) => entry[1]?.message === "estimate unavailable"));
+
+// The fallback is confined to the optional estimate, not a catch around all
+// settings rendering or saving that would conceal an unrelated regression.
+{
+  const { body, pill } = build(true, true);
+  assert.throws(() => openNeuralPopover(pill, {
+    target: body.timeline, commit: () => body.commit(),
+    geometry: () => ({ width: 832, height: 480 }),
+    picture: () => { throw new Error("unrelated picture failure"); },
+  }), /unrelated picture failure/);
+  body.destroy();
+}
+console.log(JSON.stringify({ bodyCases, fallbackCases }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+
+check("real timeline ON/OFF and readiness combinations", result["bodyCases"], 4)
+check("failing optional geometry ON/OFF and readiness combinations", result["fallbackCases"], 4)

--- a/web/creator/pills.js
+++ b/web/creator/pills.js
@@ -1099,10 +1099,19 @@ export function openNeuralPopover(anchor, { target, commit, still = false, geome
         redraw: () => render(),
       }));
       rows.push(profileRow(block, render, commit));
-      const size = geometry?.();
-      const gigabytes = size
-        ? neuralEstimateGb(size.width, size.height, still ? block.scale : 1, block.precision)
-        : null;
+      let size, gigabytes = null;
+      try {
+        size = geometry?.();
+        if (size) {
+          gigabytes = neuralEstimateGb(size.width, size.height,
+                                       still ? block.scale : 1, block.precision);
+        }
+      } catch (error) {
+        // An optional estimate must never strand a saved ON block: users need
+        // this switch even on a machine where the refiner cannot run. Keep the
+        // failure visible in the console, but let the controls render and save.
+        console.warn("[Continuity] DLSS memory estimate unavailable", error);
+      }
       rows.push(el("div", { class: "mmc-pop-note", text: [
         gigabytes != null
           ? t("About {gb} GB of VRAM per frame at {width} × {height}.",

--- a/web/creator/timeline.js
+++ b/web/creator/timeline.js
@@ -3978,7 +3978,8 @@ export class TimelineBody {
           ? [facesPill({ target: this.timeline, commit: () => this.commit() })] : []),
         // The DLSS 5 refiner, family-neutral: it runs over decoded frames.
         neuralPill({ target: this.timeline, commit: () => this.commit(),
-                     geometry: () => this.geometry(),
+                     // TimelineBody has no geometry() method; the modal does.
+                     geometry: () => timelineGeometry(this.timeline),
                      picture: () => stageSource(this.stage?.result) }),
         weightsPill({
           piece: this.timeline,


### PR DESCRIPTION
Related to #54, items 1 and 2. This is a focused fix, not a request to close the entire issue.

## Problem

- In a Timeline body, opening the enabled DLSS popover calls `this.geometry()`, but that method belongs to a different class. Rendering the popover throws before it can be attached, preventing the user from turning DLSS off. This does not require installed weights to reproduce.
- A reel made entirely of held takes contains clips, not generated passes. `NeuralPass` currently rejects this valid reel before export, even though those takes do not need another neural pass.

## Changes

- **`web/creator/timeline.js`**: use the existing `timelineGeometry(this.timeline)` helper specifically in `TimelineBody`; other classes retain their own geometry methods.
- **`web/creator/pills.js`**: isolate optional VRAM-estimate failures so the ON/OFF controls and saving remain usable. This does not suppress unrelated editing errors.
- **`creator/neuralpass.py`**: return a valid clip-only reel unchanged before loading optional weights. Empty/malformed reels still fail, and generated/mixed reels keep their existing processing and cleanup.

The comments explain the class boundary and why held takes must not be refined twice. No default is silently changed and no weights are installed.

## Validation

Added `test_neural_popup.py` and `test_neural_clip_reel.py`:

- Actual Timeline-body and shared-popover code, ON/OFF/readiness combinations, a failing geometry estimate, OFF serialization/reload, and unrelated save/error controls.
- Actual CPU node execution without weights, clip-only passthrough, invalid input, generated-weight checks, and mixed-reel ordering/progress/cleanup.
- Existing `test_js_bodies.py` also passes.

**Boundary:** DOM/CPU regression coverage, not an actual browser interaction or H3/DLSS GPU render. Existing installed node files were not modified for this PR.
