### PR TITLE
Preserve merged reference identity and video sizes

### DIFF
--- a/creator/compile.py
+++ b/creator/compile.py
@@ -3147,7 +3147,10 @@ def _asset_dict(asset):
            "filename": asset.filename}
     if asset.track:
         out["track"] = asset.track
-    if asset.ref_size != "match":
+    # Video parsing defaults to max, unlike images. Omitting an explicit match
+    # here changes both the reference canvas and the memory cost after a merge
+    # or pool injection. Keep existing max serialization/cache keys unchanged.
+    if asset.kind == "video" or asset.ref_size != "match":
         out["ref_size"] = asset.ref_size
     if asset.trim:
         out["trim"] = {"start": asset.trim[0], "end": asset.trim[1]}
@@ -3253,6 +3256,17 @@ def _agree(values, what, blank=""):
     return distinct[0] if distinct else blank
 
 
+def _asset_identity(asset):
+    """What a reference means, without its card-local spelling.
+
+    A sheet's ordered panel metadata is part of its meaning, not just its
+    filename. Aliases can deduplicate; different cuts, layouts or roles cannot.
+    """
+    return (asset.kind, asset.role, asset.filename, asset.track, asset.ref_size,
+            asset.trim, asset.takes, asset.cut, asset.op, asset.rect,
+            tuple(_asset_identity(panel) for panel in asset.panels))
+
+
 def group_payload(data, start=0, end=None):
     """`timeline_data` + a run of segments -> one payload generating all of them.
 
@@ -3263,7 +3277,7 @@ def group_payload(data, start=0, end=None):
 
     - **One reference pool.** Handles are allocated per segment, so `img-1`
       means a different file in each of them. Every segment's attachments are
-      merged — same file, role and trim is the same reference, which is the point:
+      merged — same file, role, trim and panel interpretation is the same reference:
       a face cited in shot 1 and again in shot 4 is one `<Picture N>` — and each
       shot's prompt is rewritten onto the merged handles before the labels are
       assigned. There is no second labelling scheme; `compile_request` does it.
@@ -3291,7 +3305,7 @@ def group_payload(data, start=0, end=None):
     last_number = start + len(group)
     global_prompt = str(data.get("prompt") or "").strip()
     pool = timeline_pool(data)
-    pool_handles = {asset.handle for asset in pool}
+    pool_identities = {asset.handle: _asset_identity(asset) for asset in pool}
     cast = timeline_cast(data)
     # A card's own assets are renamed onto the merged list, so a subject built
     # out of one has to be renamed with them. Accumulated across the shots and
@@ -3309,7 +3323,54 @@ def group_payload(data, start=0, end=None):
     assets = []          # the merged reference list, in first-appearance order
     position_of = {}     # dedup key -> index into `assets`
     counters = {}        # kind -> how many merged handles of it exist
+    # Owners and panels share one namespace when the request is parsed again.
+    # Reserve the pool up front: a reference first cited in a later shot must
+    # not collide with a local owner or panel allocated by an earlier shot.
+    reserved = {handle for asset in pool
+                for handle in (asset.handle, *(p.handle for p in asset.panels))}
+    used = reserved | {subject.handle for subject in cast}
+    claimed = set()
+    cast_handles = {subject.handle for subject in cast}
+
+    def allocate(kind, preferred=None, pooled=False):
+        # A pool entry may claim its reservation, but a shot-local override of
+        # that entry is a second reference if its content/metadata differs.
+        if preferred and preferred not in (claimed if pooled else used):
+            used.add(preferred)
+            claimed.add(preferred)
+            return preferred
+        while True:
+            counters[kind] = counters.get(kind, 0) + 1
+            handle = f"{_HANDLE_PREFIX[kind]}-{counters[kind]}"
+            if handle not in used:
+                used.add(handle)
+                claimed.add(handle)
+                return handle
+
+    def merged_asset(asset):
+        identity = _asset_identity(asset)
+        # A local override has the pool's spelling, not its identity. Letting it
+        # claim the reserved name would silently redirect unchanged global prose.
+        pooled = pool_identities.get(asset.handle) == identity
+        conflict = cast_handles.intersection(
+            [asset.handle, *(panel.handle for panel in asset.panels)])
+        if conflict:
+            handle = sorted(conflict)[0]
+            raise CompileError(f"@{handle} is both a subject and an attached file — "
+                               "one @ must mean one thing; rename one of them")
+        key = (asset.handle if pooled else None, identity)
+        position = position_of.get(key)
+        if position is None:
+            position = position_of[key] = len(assets)
+            handle = allocate(asset.kind, asset.handle if pooled else None, pooled)
+            assets.append(replace(
+                asset, handle=handle,
+                panels=tuple(replace(panel, handle=allocate(panel.kind, panel.handle, pooled))
+                             for panel in asset.panels)))
+        return assets[position]
+
     shots = []           # (cut time in seconds, text) per shot
+    audio_fields = {key: [str(data.get(key) or "")] for key in ("soundscape", "music")}
     at = 0.0
     stack = data.get("loras")
     piece_aspect_source = data.get("aspect_source")
@@ -3337,6 +3398,18 @@ def group_payload(data, start=0, end=None):
         except CompileError as exc:
             raise CompileError(f"shot {number}: {exc}") from exc
 
+        if number == first_number:
+            # Normally _inject_pool already supplies these in pool order. Only
+            # seed an original that the first card shadows: the unrenamed global
+            # description must still mean that original, even if every card has
+            # its own override. Ordinary payload ordering/cache keys stay put.
+            for asset in cited_pool(pool, {}, extra_texts=global_texts, cast=cast):
+                if not any(a.handle == asset.handle and _asset_identity(a) == _asset_identity(asset)
+                           for a in parsed):
+                    merged_asset(asset)
+                    for handle in (asset.handle, *(panel.handle for panel in asset.panels)):
+                        cast_rename.setdefault(handle, handle)
+
         rename = {}
         for asset in parsed:
             if asset.role == "first_frame" and number != first_number:
@@ -3353,33 +3426,21 @@ def group_payload(data, start=0, end=None):
                     f"makes, so it can only be that shot's. Split the pass after shot "
                     f"{number} to give it one of its own."
                 )
-            # A pool asset keys — and keeps — its own handle: the global prompt
-            # is prepended to shot 1's text *without* the shot's rename pass,
-            # so a citation there only resolves if the merged list still calls
-            # the asset what the pool does. Its handle is globally unique
-            # already, which is the ref- prefix's whole job.
-            pooled = asset.handle in pool_handles
-            key = (asset.handle if pooled else None,
-                   asset.kind, asset.role, asset.filename, asset.track,
-                   asset.ref_size, asset.trim, asset.takes)
-            position = position_of.get(key)
-            if position is None:
-                position = position_of[key] = len(assets)
-                if pooled:
-                    assets.append(asset)
-                else:
-                    counters[asset.kind] = counters.get(asset.kind, 0) + 1
-                    assets.append(replace(
-                        asset, handle=f"{_HANDLE_PREFIX[asset.kind]}-{counters[asset.kind]}"))
-            rename[asset.handle] = assets[position].handle
-            cast_rename.setdefault(asset.handle, assets[position].handle)
+            target_asset = merged_asset(asset)
+            rename[asset.handle] = target_asset.handle
+            cast_rename.setdefault(asset.handle, target_asset.handle)
+            # Also map aliases on a deduplicated sheet: retaining only its first
+            # owner's name leaves later shots citing panels that were discarded.
+            for source, target in zip(asset.panels, target_asset.panels):
+                rename[source.handle] = target.handle
+                cast_rename.setdefault(source.handle, target.handle)
             # The piece's chosen aspect source, carried through the merge: the
             # request below is a single generation, so `{card, handle}` has to
             # become the handle the asset wears after renaming.
             if (isinstance(piece_aspect_source, dict)
                     and int(piece_aspect_source.get("card") or 0) == number
                     and piece_aspect_source.get("handle") == asset.handle):
-                merged_aspect_source = assets[position].handle
+                merged_aspect_source = target_asset.handle
 
         # A refined shot replaces the typed one here rather than downstream,
         # because the merged request is a single generation and `compile_request`
@@ -3392,6 +3453,12 @@ def group_payload(data, start=0, end=None):
             lambda m: "@" + rename.get(m.group(1), m.group(1)),
             written or str(segment.get("prompt") or ""),
         ).strip()
+        # Audio prose can cite these same references. Compare/join it only
+        # after the shot's aliases have been mapped to the merged namespace.
+        for key, values in audio_fields.items():
+            values.append(HANDLE_RE.sub(
+                lambda m: "@" + rename.get(m.group(1), m.group(1)),
+                str(segment.get(key) or "")))
         # The standing description of the piece opens the description, which is
         # where the guide puts the style and the initial composition — in front
         # of typed text, and in front of a shot-scoped rewrite, which stands in
@@ -3437,8 +3504,7 @@ def group_payload(data, start=0, end=None):
         "audio_tail_s": data.get("audio_tail_s", DEFAULT_AUDIO_TAIL_S),
     }
     for key in ("soundscape", "music"):
-        request[key] = _agree(
-            [str(data.get(key) or "")] + [str(s.get(key) or "") for s in group], key)
+        request[key] = _agree(audio_fields[key], key)
     # One pass is one face pass. The cards in a merged run are a single
     # generation, so a card that turned it off inside one is asking for
     # something a pass cannot do — refused by name here rather than resolved in

--- a/creator/families/h3/segment.py
+++ b/creator/families/h3/segment.py
@@ -158,10 +158,16 @@ class MiniMaxH3TimelineSegment(io.ComfyNode):
 
     @classmethod
     def fingerprint_inputs(cls, segment_data, **kwargs):
+        # Shared file stamps live on timeline, not on this moved family node.
+        # Import lazily, as LTX does, so loading either module cannot make a
+        # circular import look like an unchanged/empty reference fingerprint.
+        from ... import timeline
+
         try:
             payload = json.loads(segment_data)
-            return (segment_data, stamps({"segments": [payload.get("request", {})],
-                                          "sound": payload.get("sound")}))
+            return (segment_data,
+                    timeline.stamps({"segments": [payload.get("request", {})],
+                                     "sound": payload.get("sound")}))
         except Exception:
             return (segment_data, ())
 

--- a/tests/test_h3_fingerprint.py
+++ b/tests/test_h3_fingerprint.py
@@ -1,0 +1,66 @@
+"""H3 fingerprints track referenced files after moving into the family package.
+
+COMFYUI_PATH points at a ComfyUI installation. This imports the actual node and
+shared stamp function on CPU; it does not start a server or load model weights.
+All file fixtures and ComfyUI base directories live in a temporary directory.
+"""
+
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+import layout
+from harness import check, skip
+
+comfy = Path(os.environ.get("COMFYUI_PATH", os.path.expanduser("~/ComfyUI")))
+if not (comfy / "folder_paths.py").is_file():
+    skip("set COMFYUI_PATH to a ComfyUI installation")
+sys.path.insert(0, str(comfy))
+
+with tempfile.TemporaryDirectory(prefix="continuity-fingerprint-") as temporary:
+    root = Path(temporary)
+    sys.argv = ["test_h3_fingerprint", "--cpu", "--base-directory", str(root)]
+    import comfy.cli_args
+    comfy.cli_args.args.cpu = True
+    import folder_paths
+    for kind in ("input", "output", "temp", "user"):
+        directory = root / kind
+        directory.mkdir()
+        getattr(folder_paths, f"set_{kind}_directory")(str(directory))
+
+    pkg = layout.load("h3_segment", "timeline", package="fingerprint_contract")
+    node = pkg.h3_segment.MiniMaxH3TimelineSegment
+    # Only path resolution is replaced; timeline.stamps really stats these files.
+    pkg.timeline.media.resolve = lambda name: str(root / name)
+    pkg.timeline.lora.resolve = lambda name: str(root / name)
+    names = ("reference.png", "motion.mp4", "speech.wav", "model.safetensors")
+    for name in names:
+        (root / name).write_bytes(b"fixture")
+        os.utime(root / name, (1700000000, 1700000000))
+
+    payload = {"request": {
+        "assets": [{"filename": name} for name in names[:2]],
+        "loras": [{"name": names[3]}]},
+        "sound": [{"filename": names[2]}]}
+    data = json.dumps(payload)
+    before = node.fingerprint_inputs(data)
+    check("payload remains part of the cache key", before[0], data)
+    check("all reference/sound/LoRA stamps are present", len(before[1]), 4)
+    check("unchanged files remain cache hits", node.fingerprint_inputs(data), before)
+    for index, name in enumerate(names, start=1):
+        os.utime(root / name, (1700000000 + index, 1700000000 + index))
+        after = node.fingerprint_inputs(data)
+        check(f"same-name replacement invalidates {name}", after != before, True)
+        check(f"{name} matches shared file stamps", after[1],
+              pkg.timeline.stamps({"segments": [payload["request"]], "sound": payload["sound"]}))
+        before = after
+
+    check("missing file keeps a stable sentinel",
+          node.fingerprint_inputs(json.dumps({"request": {"assets": [{"filename": "missing"}]}}))[1],
+          (None,))
+    check("text-only request has no file dependencies",
+          node.fingerprint_inputs(json.dumps({"request": {"prompt": "a room"}}))[1], ())
+    check("malformed JSON preserves existing fallback",
+          node.fingerprint_inputs("not json"), ("not json", ()))

--- a/tests/test_merge_sheet_handles.py
+++ b/tests/test_merge_sheet_handles.py
@@ -1,0 +1,172 @@
+"""Merged sheets keep unique handles and all aliases still cite their panels.
+
+Pure compiler tests; filenames are declarative and no images/models are loaded.
+"""
+
+import layout
+from harness import check
+
+compiler = layout.load("compile").compile
+
+
+def sheet(filename="sheet.png", handles=("img-1", "img-2")):
+    return {"handle": "plate-1", "kind": "image", "role": "reference",
+            "filename": filename, "cut": True,
+            "panels": [{"handle": handles[0], "filename": "person.png",
+                        "takes": "person", "cut": True, "rect": [0, 0, .5, 1]},
+                       {"handle": handles[1], "filename": "room.png", "takes": "scene"}]}
+
+
+def shot(asset, **rest):
+    first, second = [p["handle"] for p in asset["panels"]]
+    return {"duration_s": 3, "prompt": f"@{first} walks through @{second}.",
+            "assets": [asset], **rest}
+
+
+def merged(segments, **rest):
+    payload = compiler.group_payload({"segments": segments, **rest})
+    raw = payload["request"]["assets"]
+    handles = [handle for asset in raw
+               for handle in [asset["handle"], *[p["handle"] for p in asset.get("panels", [])]]]
+    check("all merged owner/panel handles are unique", len(handles), len(set(handles)))
+    compiled = compiler.compile_segment(payload)
+    check("no unresolved asset citations remain", "@" in compiled.body, False)
+    return payload, compiled
+
+
+# The first sheet owner used to be renamed img-1 on top of its own img-1 panel.
+original = sheet()
+unmerged = compiler.compile_segment({"request": shot(original)})
+payload, compiled = merged([shot(original), {"duration_s": 3, "prompt": "They turn."}])
+check("one sheet remains one image", len(compiled.ref_images), 1)
+check("source sheet was not mutated", original, sheet())
+check("same panel metadata after renaming",
+      [{k: v for k, v in p.items() if k != "handle"}
+       for p in payload["request"]["assets"][0]["panels"]],
+      [{k: v for k, v in p.items() if k != "handle"} for p in original["panels"]])
+check("owner cut flag survives", payload["request"]["assets"][0]["cut"], True)
+check("unmerged panel labels still exist", set(unmerged.labels), {"plate-1", "img-1", "img-2"})
+
+# A noncolliding panel keeps its handle, preserving existing payloads/cache keys.
+payload, _ = merged([shot(sheet(handles=("p-1", "p-2")))])
+check("noncolliding panel names stay stable",
+      [p["handle"] for p in payload["request"]["assets"][0]["panels"]], ["p-1", "p-2"])
+
+# Different sheets can reuse card-local panel names without becoming duplicates.
+payload, compiled = merged([shot(sheet("first.png", ("p-1", "p-2"))),
+                            shot(sheet("second.png", ("p-1", "p-2")))])
+check("distinct sheet files stay distinct", len(compiled.ref_images), 2)
+for index, asset in enumerate(payload["request"]["assets"]):
+    for panel in asset["panels"]:
+        check(f"sheet {index} panel cited after merge",
+              f"@{panel['handle']}" in payload["request"]["prompt"], True)
+    first, second = [compiled.labels[p["handle"]] for p in asset["panels"]]
+    check(f"shot {index} still cites its own panel pair",
+          f"{first} walks through {second}" in compiled.body, True)
+
+# The same sheet with different local aliases is one reference, but both shots
+# must be rewritten to its retained panel names (not left citing the discarded alias).
+payload, compiled = merged([shot(sheet(handles=("p-1", "p-2"))),
+                            shot(sheet(handles=("q-1", "q-2")))])
+check("same sheet is deduplicated", len(compiled.ref_images), 1)
+check("discarded aliases are remapped", "@q-" in payload["request"]["prompt"], False)
+check("both shots cite the retained first panel", payload["request"]["prompt"].count("@p-1"), 2)
+
+for field in ("soundscape", "music"):
+    payload, _ = merged([shot(sheet(handles=("p-1", "p-2")), **{field: "@p-1 sings."}),
+                         shot(sheet(handles=("q-1", "q-2")), **{field: "@q-1 sings."})])
+    check(f"{field} aliases agree after deduplication", payload["request"][field], "@p-1 sings.")
+
+refined = shot(sheet())
+refined["prompt"] = "unused typed prompt"
+refined["refined"] = {"body": "@img-1 faces @img-2.", "enabled": True}
+payload, compiled = merged([refined])
+first, second = [compiled.labels[p["handle"]]
+                 for p in payload["request"]["assets"][0]["panels"]]
+check("refined body follows panel remapping", f"{first} faces {second}" in compiled.body, True)
+
+# Same composite filename is not enough when its panel interpretation differs.
+for field, value in (("takes", "object"), ("filename", "other-person.png"),
+                     ("rect", [.5, 0, .5, 1]), ("cut", False)):
+    different = sheet(handles=("q-1", "q-2"))
+    different["panels"][0][field] = value
+    payload, _ = merged([shot(sheet(handles=("p-1", "p-2"))), shot(different)])
+    check(f"different panel {field} is not silently discarded", len(payload["request"]["assets"]), 2)
+
+# Pool handles are reserved even when first cited after card-local allocations.
+pooled = {"handle": "img-1", "kind": "image", "filename": "global.png"}
+payload, _ = merged([shot(sheet(handles=("p-1", "p-2"))),
+                     {"duration_s": 3, "prompt": "@img-1 remains."}], assets=[pooled])
+check("a late pool citation keeps its global handle",
+      next(a["handle"] for a in payload["request"]["assets"] if a["filename"] == "global.png"), "img-1")
+
+pooled_sheet = sheet("global-sheet.png")
+pooled_sheet["handle"] = "ref-1"
+payload, _ = merged([shot(sheet("local-sheet.png", ("p-1", "p-2"))),
+                     {"duration_s": 3, "prompt": "@ref-1 remains."}], assets=[pooled_sheet])
+check("pool panel names are reserved as well",
+      [p["handle"] for a in payload["request"]["assets"] if a["handle"] == "ref-1" for p in a["panels"]],
+      ["img-1", "img-2"])
+
+override = sheet("override.png")
+override["handle"] = "ref-1"
+payload, _ = merged([{"duration_s": 3, "prompt": "@ref-1 opens."},
+                     shot(override)], assets=[pooled_sheet])
+check("a card-local pool override keeps its different sheet",
+      [a["filename"] for a in payload["request"]["assets"]], ["global-sheet.png", "override.png"])
+
+# Reversing the order must not let an override steal a globally cited identity.
+for later in ([], [{"duration_s": 3, "prompt": "@ref-1 remains the original."}]):
+    payload, _ = merged([shot(override, prompt="@ref-1 is this card's override."), *later],
+                         assets=[pooled_sheet], prompt="Global reference: @ref-1.")
+    request = payload["request"]
+    original = next(a for a in request["assets"] if a["filename"] == "global-sheet.png")
+    changed = next(a for a in request["assets"] if a["filename"] == "override.png")
+    check("global original keeps the reserved identity", original["handle"], "ref-1")
+    check("earlier local override gets a distinct identity", changed["handle"] != "ref-1", True)
+    check("global prose still names the original", "Global reference: @ref-1." in request["prompt"], True)
+    check("card prose follows the override", f"@{changed['handle']} is this card's override." in request["prompt"], True)
+
+other_pool = {"handle": "ref-2", "kind": "image", "filename": "other-global.png"}
+payload, _ = merged([{"duration_s": 3, "prompt": "@ref-2 remains."}],
+                     assets=[other_pool, pooled_sheet], prompt="@ref-1 is the global reference.")
+check("ordinary pool ordering is unchanged", [a["handle"] for a in payload["request"]["assets"]],
+      ["ref-2", "ref-1"])
+
+ambiguous = sheet(handles=("anna", "p-2"))
+ambiguous["handle"] = "ref-1"
+for case in ({"assets": [ambiguous],
+              "segments": [{"duration_s": 3, "prompt": "@ref-1 and @anna"}]},
+             {"segments": [shot(sheet(handles=("p-1", "p-2"))),
+                           shot(sheet(handles=("anna", "p-2")))]}):
+    try:
+        compiler.group_payload({**case, "subjects": [{"handle": "anna", "description": "a woman"}]})
+    except compiler.CompileError as error:
+        check("panel/cast collision is explained", "both a subject and an attached file" in str(error), True)
+    else:
+        check("panel/cast collision must fail safely even on dedup", True, False)
+
+payload = compiler.group_payload({"segments": [shot(sheet(handles=("p-1", "p-2")))],
+                                  "subjects": [{"handle": "img_1", "description": "a woman"}]})
+check("valid subject IDs are not rewritten", payload["request"]["subjects"][0]["handle"], "img_1")
+
+# A cast referring to a local sheet panel follows that panel's merged name too.
+payload = compiler.group_payload({
+    "segments": [shot(sheet(), prompt="@anna turns beside @img-2.")],
+    "subjects": [{"handle": "anna", "from": ["img-1"],
+                  "notes": {"img-1": "the face"}}]})
+first_panel = payload["request"]["assets"][0]["panels"][0]["handle"]
+check("cast source follows panel rename", payload["request"]["subjects"][0]["from"], [first_panel])
+check("cast notes follow panel rename", payload["request"]["subjects"][0]["notes"], {first_panel: "the face"})
+
+# LTX's shared payload/reference-plan boundary uses panel labels, not picture
+# ordinals. Test that boundary without loading the optional plate renderer.
+for segments in ([shot(sheet())], [shot(sheet(handles=("p-1", "p-2"))),
+                                   shot(sheet(handles=("q-1", "q-2")))]):
+    request = compiler.group_payload({"family": "ltx25", "segments": segments})["request"]
+    assets = compiler._parse_assets(request["assets"])
+    plan = compiler.plan_references(assets, [], [], compiler.grammar.of("ltx25"))
+    body = compiler._substitute(request["prompt"], compiler._labels_from_plan(plan), assets)
+    check("LTX aliases retain one sheet", len(assets), 1)
+    check("LTX aliases still cite the same panel pair",
+          body.count("panel 1 walks through panel 2"), len(segments))

--- a/tests/test_ref_size_roundtrip.py
+++ b/tests/test_ref_size_roundtrip.py
@@ -1,0 +1,64 @@
+"""Reference size survives pool injection and merged/one-pass serialization.
+
+Runs without ComfyUI or model weights: this is the real compiler's payload
+round trip, not a render or a measurement of GPU memory.
+"""
+
+import copy
+
+import layout
+from harness import check
+
+compiler = layout.load("compile").compile
+
+
+def video(size):
+    return {"handle": "vid-1", "kind": "video", "role": "reference",
+            "filename": "motion.mp4", "track": "picture",
+            "takes": "motion", "ref_size": size}
+
+
+for kind in ("image", "video"):
+    for size in ("match", "max"):
+        raw = {"handle": "ref-1", "kind": kind, "filename": "reference",
+               "ref_size": size}
+        parsed = compiler._parse_assets([raw])[0]
+        restored = compiler._parse_assets([compiler._asset_dict(parsed)])[0]
+        check(f"{kind}/{size} round-trips", restored.ref_size, size)
+
+for size in ("match", "max"):
+    piece = {"version": 2, "family": "h3", "aspect": "1:1", "short_edge": 480,
+             "assets": [video(size)],
+             "segments": [{"duration_s": 3, "prompt": "@vid-1 walks."},
+                          {"duration_s": 3, "prompt": "@vid-1 waves."}]}
+    for location in ("pool", "local"):
+        data = copy.deepcopy(piece)
+        if location == "local":
+            assets = data.pop("assets")
+            for segment in data["segments"]:
+                segment["assets"] = copy.deepcopy(assets)
+        for mode in ("chain", "merge", "one-pass"):
+            selected = copy.deepcopy(data)
+            if mode == "merge":
+                selected["segments"][1]["merge"] = True
+            payloads = ([compiler.single_payload(selected)] if mode == "one-pass"
+                        else compiler.timeline_payloads(selected))
+            for index, payload in enumerate(payloads):
+                compiled = compiler.compile_segment(payload)
+                check(f"{location}/{mode}/{size} pass {index} keeps video size",
+                      [asset.ref_size for asset in compiled.ref_videos], [size])
+
+# Cast motion injects the video without a direct @video citation in the shot.
+piece["assets"] = [{"handle": "img-1", "kind": "image", "filename": "face.png"},
+                   video("match")]
+piece["subjects"] = [{"handle": "anna", "from": ["img-1"], "motion": "vid-1"}]
+for segment in piece["segments"]:
+    segment["prompt"] = "@anna walks."
+for payload in compiler.timeline_payloads(piece):
+    check("cast-injected motion keeps match",
+          compiler.compile_segment(payload).ref_videos[0].ref_size, "match")
+
+# Retain the existing serialization of max-sized videos: no gratuitous cache
+# key change for the common default while repairing explicit match.
+check("video max remains explicit", compiler._asset_dict(
+    compiler._parse_assets([video("max")])[0])["ref_size"], "max")


### PR DESCRIPTION
Related to #54, items 3, 8 and 12.

## Problems

1. Merging shots can assign a sheet owner the same handle as one of its panels, or retain aliases that no longer exist after deduplication.
2. Explicit video `ref_size=match` is omitted during serialization, then reparsed as the video default `max`.
3. The moved H3 segment node calls an undefined `stamps()`. Its broad exception fallback hides the error and omits referenced-file modification stamps from the fingerprint.

## Changes

- **`creator/compile.py` / `_asset_dict`** keeps explicit video reference sizes through pool injection, merged passes and one-pass round trips, while preserving existing default-max serialization.
- **`group_payload`** allocates owners/panels in a shared namespace, deduplicates by reference and panel meaning, and rewrites panel aliases in shot/refined/audio prose and cast mappings. Global references retain their identity even when an earlier card overrides the same handle. Ambiguous cast/panel collisions fail with a clear error.
- **`creator/families/h3/segment.py` / `fingerprint_inputs`** calls the existing `timeline.stamps()` through a lazy import, avoiding the family/timeline import cycle.

Comments describe ownership, pool reservations, explicit-default serialization and the import boundary. This does not add a new cast-panel feature or change the underlying model.

## Validation

New `test_merge_sheet_handles.py`, `test_ref_size_roundtrip.py`, and `test_h3_fingerprint.py` cover alias/dedup/override order, global references shadowed on every card, panel metadata, H3/LTX reference-plan boundaries, pool/local/merged/one-pass video sizes, and actual file-stat fingerprint changes. Existing compiler and subjects suites pass.

**Boundary:** compiler and CPU fingerprint tests, not model inference or measured GPU memory usage.
