### PR TITLE
Preserve VFR trim intervals and audio timestamps

### DIFF
--- a/creator/bench.py
+++ b/creator/bench.py
@@ -313,15 +313,22 @@ def video_frame(path, at):
         # Read before the seek: it decodes one frame and winds the container
         # back to the top, so it has to come before anything positions it.
         rotation = media.stream_rotation(container, stream)
+        mark = Fraction(str(at)) + (stream.start_time or 0) * (stream.time_base or 0)
         if at > 0 and stream.time_base:
             try:
-                container.seek(int(at / stream.time_base), stream=stream)
+                container.seek(int(mark / stream.time_base), stream=stream)
             except Exception:  # noqa: BLE001 — an unseekable container decodes from zero
                 container.seek(0)
         last = None
         for frame in container.decode(stream):
+            # A frame remains on screen until the next one's timestamp. At a
+            # mark inside that hold, the next frame is not the displayed one.
+            when = (frame.pts * frame.time_base
+                    if frame.pts is not None and frame.time_base else None)
+            if when is not None and when > mark and last is not None:
+                break
             last = frame
-            if frame.time is not None and frame.time >= at:
+            if when is not None and when >= mark:
                 break
         if last is None:
             raise BenchError(f"{os.path.basename(path)} has no decodable frame")
@@ -330,6 +337,50 @@ def video_frame(path, at):
         # the still it exports are the picture the player shows, not the
         # storage picture lying on its side (issue #47).
         return media.turned(last.to_ndarray(format="rgb24"), rotation)
+
+
+def _video_window(container, stream, start, end, rate):
+    """Yield (window-relative start, end, frame) for intersecting display intervals.
+
+    One-frame lookahead keeps VFR timing without expanding held frames into
+    CFR duplicates (and running an expensive image operator on each duplicate).
+    The first and last intervals are clipped, even if the entire cut is inside
+    one hold. Source timestamps are relative to the video's own start.
+    """
+    tick = stream.time_base or Fraction(1, 90000)
+    origin = (stream.start_time or 0) * tick
+    first = origin + Fraction(str(start))
+    stop = origin + Fraction(str(end)) if end is not None else None
+    if start > 0:
+        try:
+            container.seek(int(first / tick), stream=stream)
+        except Exception:  # noqa: BLE001 — unseekable footage is read from the top
+            container.seek(0)
+    previous = None
+    previous_at = None
+
+    def interval(frame, at, until):
+        left, right = max(first, at), min(stop, until) if stop is not None else until
+        if right > left:
+            yield left - first, right - first, frame
+
+    for frame in container.decode(stream):
+        if frame.pts is None:
+            continue
+        at = frame.pts * (frame.time_base or tick)
+        if previous is not None:
+            yield from interval(previous, previous_at, at)
+        if stop is not None and at >= stop:
+            return
+        previous, previous_at = frame, at
+    if previous is not None:
+        duration = getattr(previous, "duration", 0)
+        period = (duration * (previous.time_base or tick)
+                  if duration else Fraction(1, 1) / rate)
+        until = previous_at + period
+        if stream.duration is not None:
+            until = max(until, origin + stream.duration * tick)
+        yield from interval(previous, previous_at, until)
 
 
 def source_frame(path, at=0.0, long_edge=PREVIEW_LONG_EDGE):
@@ -497,7 +548,10 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
                 video = out.add_stream("libx264", rate=rate)
                 video.width, video.height = width, height
                 video.pix_fmt = "yuv420p"
-                video.options = {"crf": str(crf), "preset": "medium"}
+                # Reordered B-frame DTS can shorten an MP4's reported duration
+                # on sparse VFR despite correct display PTS. Keep encode order
+                # on the source clock so each packet's duration is its hold.
+                video.options = {"crf": str(crf), "preset": "medium", "bf": "0"}
                 # The source's own tick, not one over the frame rate, and the frames
                 # keep their own timestamps against it — because the result has to
                 # line up with the footage frame for frame. Counting frames out at a
@@ -508,22 +562,14 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
                 video.codec_context.time_base = tick
                 audio_out = None
                 fifo = None
-                resampler = None
                 if audio_in is not None:
                     audio_out = out.add_stream("aac", rate=audio_in.rate)
                     audio_out.layout = "stereo" if audio_in.channels >= 2 else "mono"
                     fifo = av.AudioFifo()
-                    resampler = av.audio.resampler.AudioResampler(
-                        format="fltp", layout=audio_out.layout, rate=audio_in.rate)
-
-                if start > 0 and stream.time_base:
-                    try:
-                        source.seek(int(start / stream.time_base), stream=stream)
-                    except Exception:  # noqa: BLE001
-                        source.seek(0)
 
                 written = 0
-                zero = None
+                seconds = Fraction(0)
+                durations = {}
                 # The frames waiting to go through `work` — each with the timestamp
                 # it came in on, because what is written has to line up with the
                 # footage frame for frame — and the tail of the last chunk's answer,
@@ -532,15 +578,27 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
                 held = []
                 fade = _fade(overlap) if overlap else []
 
-                def emit(pts, done):
-                    nonlocal written
+                def mux_video(packets):
+                    for packet in packets:
+                        # libx264 may buffer/reorder frames, so associate the
+                        # clipped display duration with its PTS, not with the
+                        # call to encode that happened to return the packet.
+                        duration = durations.pop(packet.pts, None)
+                        if duration is not None:
+                            packet.duration = round(duration * tick / packet.time_base)
+                        out.mux(packet)
+
+                def emit(pts, duration, done):
+                    nonlocal written, seconds
                     if done.shape[1] != width or done.shape[0] != height:
                         done = np.asarray(
                             Image.fromarray(done).resize((width, height), Image.LANCZOS))
                     picture = av.VideoFrame.from_ndarray(done, format="rgb24")
-                    picture.pts = pts - zero
+                    picture.pts = pts
                     picture.time_base = tick
-                    out.mux(video.encode(picture))
+                    durations[pts] = duration
+                    mux_video(video.encode(picture))
+                    seconds = max(seconds, (pts + duration) * tick)
                     written += 1
                     if on_progress and expected and written % every == 0:
                         on_progress(min(0.99, written / expected))
@@ -554,7 +612,7 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
                     nothing is written twice and nothing is written early.
                     """
                     nonlocal waiting, held
-                    answer = work([picture for _, picture in waiting])
+                    answer = work([picture for _, _, picture in waiting])
                     if len(answer) != len(waiting):
                         raise BenchError("the work gave back a different number of frames")
                     for index, weight in enumerate(fade[:len(held)]):
@@ -562,57 +620,52 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
                                          + answer[index].astype(np.float32) * (1 - weight)
                                          ).round().clip(0, 255).astype(np.uint8)
                     keep = 0 if last else min(overlap, len(answer) - 1)
-                    for (pts, _), done in zip(waiting[:len(answer) - keep], answer):
-                        emit(pts, done)
+                    for (pts, duration, _), done in zip(waiting[:len(answer) - keep], answer):
+                        emit(pts, duration, done)
                     held = answer[len(answer) - keep:] if keep else []
                     waiting = waiting[len(waiting) - keep:] if keep else []
 
-                streams = [stream] + ([audio_in] if audio_in is not None else [])
-                for frame in source.decode(*streams):
-                    when = frame.time
-                    if when is None:
+                for left, right, frame in _video_window(source, stream, start, end, rate):
+                    pts, stop = round(left / tick), round(right / tick)
+                    if stop <= pts:
                         continue
-                    if when < start:
-                        continue
-                    if end is not None and when >= end:
-                        # Video and audio do not run out together, so this only stops
-                        # the stream that has passed the mark.
-                        if isinstance(frame, av.VideoFrame):
-                            break
-                        continue
-                    if isinstance(frame, av.VideoFrame):
-                        if frame.pts is None:
-                            continue
-                        if zero is None:
-                            zero = frame.pts
-                        waiting.append((frame.pts,
-                                        media.turned(frame.to_ndarray(format="rgb24"), rotation)))
-                        if len(waiting) >= max(1, chunk):
-                            run_chunk(last=False)
-                    elif audio_out is not None:
-                        for block in resampler.resample(frame):
-                            block.pts = None
-                            fifo.write(block)
-                            # Not `chunk`: that is this function's frames-per-work
-                            # parameter, and a walrus here rebound it to an audio
-                            # frame and then to None, so the next video frame hit
-                            # `max(1, None)`. Every upscale of a clip with sound
-                            # died there — `keep_sound` defaults to true on that
-                            # bench — after the model had already run.
-                            while (piece := fifo.read(audio_out.frame_size)) is not None:
-                                out.mux(audio_out.encode(piece))
+                    waiting.append((pts, stop - pts,
+                                    media.turned(frame.to_ndarray(format="rgb24"), rotation)))
+                    if len(waiting) >= max(1, chunk):
+                        run_chunk(last=False)
 
                 # Whatever the last full chunk did not cover, including the frames
                 # held back for a crossfade that now has nothing to fade into.
                 if waiting:
                     run_chunk(last=True)
 
-                if audio_out is not None:
+                mux_video(video.encode(None))
+                if audio_out is not None and written:
+                    # A separate audio-only pass shares the reel's timestamp
+                    # placement and is bounded by the picture just written.
+                    # It cannot stop early because a video packet crossed the
+                    # trim, or concatenate a missing second onto the end.
+                    from .mux import sound_blocks
+
+                    audio_start = start + float((stream.start_time or 0) * tick)
+                    audio_samples = 0
+                    for data in sound_blocks(av, path, audio_start, float(seconds),
+                                             audio_in.rate, audio_out.layout.name):
+                        block = av.AudioFrame.from_ndarray(
+                            np.ascontiguousarray(data), format="fltp", layout=audio_out.layout.name)
+                        block.sample_rate = audio_in.rate
+                        # Explicit sample PTS lets the muxer remove AAC encoder
+                        # priming rather than adding an extra frame of silence.
+                        block.pts = audio_samples
+                        block.time_base = Fraction(1, audio_in.rate)
+                        audio_samples += block.samples
+                        fifo.write(block)
+                        while (piece := fifo.read(audio_out.frame_size)) is not None:
+                            out.mux(audio_out.encode(piece))
                     leftover = fifo.read()
                     if leftover is not None:
                         out.mux(audio_out.encode(leftover))
                     out.mux(audio_out.encode(None))
-                out.mux(video.encode(None))
     except BaseException:
         # A run that dies partway has already created the file, and
         # `free_name` counts up — so a bench pressed three times left three
@@ -623,6 +676,7 @@ def transcode(path, out_dir, name_stem, work, size=None, trim=None, chunk=1,
         raise
 
     if not written:
-        os.remove(target)
+        if os.path.exists(target):
+            os.remove(target)
         raise BenchError("that cut has no frames in it")
     return name

--- a/creator/mux.py
+++ b/creator/mux.py
@@ -55,6 +55,7 @@ frame count and a sample count.
 """
 
 import json
+import math
 from dataclasses import dataclass, field
 from fractions import Fraction
 
@@ -586,59 +587,87 @@ def _mixed(av, waveform, blocks, target):
     return out.clamp_(-1.0, 1.0)
 
 
-def _clip_sound(av, path, spec, start, duration, target):
-    """A supplied clip's soundtrack, at the reel's rate and layout.
+def sound_blocks(av, path, start, duration, rate, layout):
+    """Planar float32 blocks on the requested window's sample clock.
 
-    Resampled by ffmpeg rather than by hand: the rate conversion, the format
-    and — where a source is mono or 5.1 — the channel mix are all things it has
-    correct matrices for and we would be inventing. A clip whose container
-    carries no sound at all comes back empty and is padded to its own length by
-    `_fit`, which is what a silent shot is.
+    Both the reel and the bench use this reading. Concatenating decoded blocks
+    preserves neither an initial delay nor a gap *between* packets: position
+    every resampled block by its own PTS, pad holes, and trim overlaps (the
+    already-written samples win). Silence is streamed in bounded chunks.
     """
     with av.open(path) as container:
         stream = next(iter(container.streams.audio), None)
         if stream is None:
-            return torch.zeros(target.channels, 0)
+            return
         resampler = av.audio.resampler.AudioResampler(
-            format="fltp", layout=target.layout, rate=target.rate)
+            format="fltp", layout=layout, rate=rate)
+        channels = len(av.AudioLayout(layout).channels)
+        origin = Fraction(str(start))
         end = start + duration if duration else None
+        wanted = int(round(duration * rate)) if duration else None
+        timestamp_tick = rate * (stream.time_base or Fraction(1, rate))
+        jitter = math.ceil(timestamp_tick) if timestamp_tick > 1 else 0
         if start:
             container.seek(int(start / stream.time_base), stream=stream)
-        blocks = []
-        # A seek lands on a packet boundary, which is at or *before* the window
-        # — so the first frame kept usually begins early. How early is what
-        # gets dropped off the front, and dropping it is what keeps the sound
-        # in step with a picture that was cut at the frame.
-        began = None
+        cursor = 0
+        placed = False
+
+        def silence(until):
+            nonlocal cursor
+            if wanted is not None:
+                until = min(until, wanted)
+            while cursor < until:
+                count = min(until - cursor, rate)
+                cursor += count
+                yield np.zeros((channels, count), dtype=np.float32)
+
+        def place(block):
+            nonlocal cursor, placed
+            at = (round((block.pts * block.time_base - origin) * rate)
+                  if block.pts is not None and block.time_base else cursor)
+            # Matroska commonly rounds packet PTS to milliseconds while PCM
+            # blocks contain an exact sample count. Within one source tick,
+            # keep the sample clock instead of inserting tiny clicks every
+            # packet. A real gap/delay larger than that still keeps its PTS.
+            if placed and abs(at - cursor) <= jitter:
+                at = cursor
+            data = block.to_ndarray()
+            # Includes samples preceding a fractional trim and duplicated or
+            # overlapping packets; neither is allowed to shift later sound.
+            skip = max(0, cursor - at)
+            if skip >= data.shape[-1]:
+                return
+            at += skip
+            yield from silence(at)
+            count = data.shape[-1] - skip
+            if wanted is not None:
+                count = min(count, wanted - cursor)
+            if count > 0:
+                cursor += count
+                placed = True
+                yield data[..., skip:skip + count]
+
         for frame in container.decode(stream):
             if frame.time is not None:
                 if frame.time + frame.samples / float(frame.sample_rate or 1) <= start:
                     continue
                 if end is not None and frame.time >= end:
                     break
-                if began is None:
-                    began = frame.time
             for out in resampler.resample(frame):
-                blocks.append(torch.from_numpy(out.to_ndarray()))
+                yield from place(out)
         for out in resampler.resample(None):
-            blocks.append(torch.from_numpy(out.to_ndarray()))
+            yield from place(out)
+        if wanted is not None:
+            yield from silence(wanted)
+
+
+def _clip_sound(av, path, spec, start, duration, target):
+    """A supplied clip's timestamped soundtrack, at the reel's rate/layout."""
+    blocks = [torch.from_numpy(block) for block in sound_blocks(
+        av, path, start, duration, target.rate, target.layout)]
     if not blocks:
         return torch.zeros(target.channels, 0)
-    waveform = torch.cat(blocks, dim=-1)
-    # ...and the other way round: sound that begins *after* the window opens
-    # — a track whose first packet sits a second in — used to be laid at the
-    # window's start, a second early, with the missing second padded onto the
-    # end by `_fit`. Its place is where it was in the file (issue #47).
-    offset = (began if began is not None else start) - start
-    if offset < 0:
-        early = int(round(-offset * target.rate))
-        return waveform[..., early:] if early else waveform
-    late = int(round(offset * target.rate))
-    if late:
-        waveform = torch.cat(
-            [torch.zeros(waveform.shape[:-1] + (late,), dtype=waveform.dtype), waveform],
-            dim=-1)
-    return waveform
+    return torch.cat(blocks, dim=-1)
 
 
 def write(path, parts, fps, crf, metadata=None):

--- a/tests/test_audio_timestamps.py
+++ b/tests/test_audio_timestamps.py
@@ -1,0 +1,159 @@
+"""Real audio packet gaps and delayed starts survive reel/bench writes (#54).
+
+    COMFYUI_PATH=~/ComfyUI <comfy-venv>/bin/python tests/test_audio_timestamps.py
+
+Lossless synthetic inputs distinguish missing packets from encoded silence;
+the output is decoded AAC and checked in windows away from codec priming.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from fractions import Fraction
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, os.environ.get("COMFYUI_PATH", os.path.expanduser("~/ComfyUI")))
+import av
+import numpy as np
+import layout
+
+pkg = layout.load("bench", "mux", package="audio_timestamp_tests")
+bench, mux = pkg.bench, pkg.mux
+
+
+def audio_video(path, spans, rate=48000, channels=2, seconds=3, packet_samples=1000):
+    """Only `spans` contain audio packets; everything else is a timestamp gap."""
+    with av.open(str(path), "w") as out:
+        video = out.add_stream("libx264", rate=24)
+        video.width, video.height, video.pix_fmt = 64, 32, "yuv420p"
+        audio = out.add_stream("pcm_f32le", rate=rate)
+        audio.layout = "stereo" if channels == 2 else "mono"
+        for i in range(round(seconds * 24)):
+            frame = av.VideoFrame.from_ndarray(np.full((32, 64, 3), 80, np.uint8), "rgb24")
+            frame.pts, frame.time_base = i, Fraction(1, 24)
+            out.mux(video.encode(frame))
+        for start, stop in spans:
+            first, final = round(start * rate), round(stop * rate)
+            for offset in range(first, final, packet_samples):
+                count = min(packet_samples, final - offset)
+                tone = (0.25 * np.sin(2 * np.pi * 440 * np.arange(offset, offset + count) / rate))
+                data = np.tile(tone.astype(np.float32), (channels, 1))
+                frame = av.AudioFrame.from_ndarray(data, format="fltp", layout=audio.layout.name)
+                frame.sample_rate = rate
+                frame.pts, frame.time_base = offset, Fraction(1, rate)
+                out.mux(audio.encode(frame))
+        out.mux(audio.encode(None))
+        out.mux(video.encode(None))
+
+
+def decoded_audio(path):
+    with av.open(str(path)) as source:
+        frames = list(source.decode(audio=0))
+        return np.concatenate([frame.to_ndarray() for frame in frames], axis=-1), frames[0].sample_rate
+
+
+def rms(samples, rate, start, stop):
+    window = samples[..., round(start * rate):round(stop * rate)]
+    return float(np.sqrt(np.mean(window.astype(np.float64) ** 2)))
+
+
+class AudioTimestamps(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(self.scratch.cleanup)
+        self.directory = Path(self.scratch.name)
+
+    def write_output(self, source, route, start=0.0, duration=3.0):
+        if route == "bench":
+            name = bench.transcode(str(source), str(self.directory), "bench",
+                                   work=lambda frames: frames, keep_sound=True,
+                                   trim=(start, start + duration), chunk=4, overlap=2)
+            return self.directory / name
+        output = self.directory / "reel.mp4"
+        mux.write(str(output), [{"clip": {"path": str(source), "start": start,
+                  "duration": duration, "width": 64, "height": 32,
+                  "sound": True, "rate": 48000, "channels": 2}}], fps=24, crf=1)
+        return output
+
+    def test_internal_gap_and_initial_delay_in_both_writers(self):
+        for label, spans, levels in [
+            ("gap", [(0, 1), (2, 3)], [True, False, True]),
+            ("late", [(1, 3)], [False, True, True]),
+            ("continuous", [(0, 3)], [True, True, True]),
+        ]:
+            source = self.directory / f"{label}.mkv"
+            audio_video(source, spans)
+            for route in ("reel", "bench"):
+                with self.subTest(source=label, route=route):
+                    samples, rate = decoded_audio(self.write_output(source, route))
+                    for second, audible in enumerate(levels):
+                        level = rms(samples, rate, second + 0.1, second + 0.9)
+                        self.assertGreater(level, 0.1) if audible else self.assertLess(level, 0.002)
+
+    def test_trim_rebases_gap_and_clips_partial_audio_blocks(self):
+        source = self.directory / "trim.mkv"
+        audio_video(source, [(0, 1), (2, 3)])
+        for route in ("reel", "bench"):
+            with self.subTest(route=route):
+                samples, rate = decoded_audio(self.write_output(source, route, 0.75, 1.5))
+                self.assertGreater(rms(samples, rate, 0.05, 0.2), 0.1)
+                self.assertLess(rms(samples, rate, 0.35, 1.15), 0.002)
+                self.assertGreater(rms(samples, rate, 1.3, 1.45), 0.1)
+                self.assertLessEqual(samples.shape[-1], round(1.5 * rate) + 1024)
+
+    def test_resampling_mono_preserves_gaps_and_duration(self):
+        source = self.directory / "mono.mkv"
+        audio_video(source, [(0, 1), (2, 3)], rate=44100, channels=1)
+        target = SimpleNamespace(rate=48000, layout="stereo", channels=2)
+        samples = mux._clip_sound(av, str(source), {}, 0.25, 2.5, target).numpy()
+        self.assertEqual(samples.shape, (2, 120000))
+        self.assertGreater(rms(samples, 48000, 0.1, 0.65), 0.1)
+        self.assertLess(rms(samples, 48000, 0.9, 1.65), 0.002)
+        self.assertGreater(rms(samples, 48000, 1.9, 2.4), 0.1)
+
+    def test_overlapping_packets_do_not_extend_or_shift_the_track(self):
+        source = self.directory / "overlap.mkv"
+        # Two one-second packets overlap by half a second. Timestamp placement
+        # keeps 1.5 seconds of sound, not two seconds followed by a shifted cut.
+        audio_video(source, [(0, 1), (0.5, 1.5)], seconds=2, packet_samples=48000)
+        for route in ("reel", "bench"):
+            with self.subTest(route=route):
+                samples, rate = decoded_audio(self.write_output(source, route, duration=2))
+                self.assertGreater(rms(samples, rate, 1.1, 1.4), 0.1)
+                self.assertLess(rms(samples, rate, 1.65, 1.9), 0.002)
+
+    def test_audio_flush_is_sample_exact_after_rate_conversion(self):
+        source = self.directory / "short-mono.mkv"
+        audio_video(source, [(0, 1)], rate=44100, channels=1, seconds=1,
+                    packet_samples=44100)
+        target = SimpleNamespace(rate=48000, layout="stereo", channels=2)
+        samples = mux._clip_sound(av, str(source), {}, 0, 0, target).numpy()
+        self.assertEqual(samples.shape, (2, 48000))
+        self.assertGreater(rms(samples, 48000, 0.95, 0.99), 0.1)
+
+    def test_coarse_container_timestamps_do_not_create_tiny_packet_gaps(self):
+        source = self.directory / "rounded-pts.mkv"
+        audio_video(source, [(0, 1)], seconds=1)
+        target = SimpleNamespace(rate=48000, layout="stereo", channels=2)
+        samples = mux._clip_sound(av, str(source), {}, 0, 0, target).numpy()
+        expected = (0.25 * np.sin(2 * np.pi * 440 * np.arange(48000) / 48000)).astype(np.float32)
+        self.assertEqual(samples.shape, (2, 48000))
+        np.testing.assert_array_equal(samples[0], expected)
+
+    def test_later_reel_part_stays_on_its_own_sample_clock(self):
+        source = self.directory / "gap-part.mkv"
+        audio_video(source, [(0, 1), (2, 3)])
+        output = self.directory / "two-parts.mp4"
+        clip = {"path": str(source), "start": 0, "duration": 3, "width": 64,
+                "height": 32, "sound": True, "rate": 48000, "channels": 2}
+        mux.write(str(output), [{"clip": clip}, {"clip": dict(clip)}], fps=24, crf=1)
+        samples, rate = decoded_audio(output)
+        for second, audible in enumerate([True, False, True] * 2):
+            level = rms(samples, rate, second + 0.1, second + 0.9)
+            self.assertGreater(level, 0.1) if audible else self.assertLess(level, 0.002)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_timestamps.py
+++ b/tests/test_bench_timestamps.py
@@ -1,0 +1,122 @@
+"""CPU/PyAV regressions for the bench's source display intervals (#54).
+
+    COMFYUI_PATH=~/ComfyUI <comfy-venv>/bin/python tests/test_bench_timestamps.py
+
+No weights are loaded: the image operator is the identity, but the fixtures,
+transcode and inspection are real encodes/decodes, not mocked timestamps.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from fractions import Fraction
+from pathlib import Path
+
+sys.path.insert(0, os.environ.get("COMFYUI_PATH", os.path.expanduser("~/ComfyUI")))
+import av
+import numpy as np
+import layout
+
+bench = layout.load("bench", package="bench_timestamp_tests").bench
+
+
+def video_file(path, stamps, rate=24, rotation=None):
+    with av.open(str(path), "w") as out:
+        video = out.add_stream("libx264", rate=rate)
+        video.width, video.height, video.pix_fmt = 64, 32, "yuv420p"
+        video.codec_context.time_base = Fraction(1, 24000)
+        video.options = {"crf": "1", "bf": "0"}
+        if rotation is not None:
+            video.set_display_rotation(rotation)
+        for when, level in stamps:
+            pixels = np.full((32, 64, 3), level, np.uint8)
+            pixels[:16, :32] = min(255, level + 40)
+            frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+            frame.pts = round(when * 24000)
+            frame.time_base = Fraction(1, 24000)
+            out.mux(video.encode(frame))
+        out.mux(video.encode(None))
+
+
+def inspect(path):
+    with av.open(str(path)) as source:
+        stream = source.streams.video[0]
+        duration = float(stream.duration * stream.time_base)
+        frames = [(frame.time, frame.to_ndarray(format="rgb24"))
+                  for frame in source.decode(stream)]
+    return duration, frames
+
+
+class BenchTimestamps(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(self.scratch.cleanup)
+        self.directory = Path(self.scratch.name)
+        self.source = self.directory / "sparse.mp4"
+        video_file(self.source, [(float(i), 20 + 25 * i) for i in (0, 1, 2, 3, 4, 6)])
+
+    def transcode(self, source=None, **kwargs):
+        name = bench.transcode(str(source or self.source), str(self.directory), "out",
+                               work=lambda frames: frames, **kwargs)
+        return inspect(self.directory / name)
+
+    def test_still_uses_frame_showing_at_fractional_mark(self):
+        expected = dict(inspect(self.source)[1])[2.0]
+        np.testing.assert_array_equal(bench.video_frame(str(self.source), 2.5), expected)
+        np.testing.assert_array_equal(bench.video_frame(str(self.source), 2.0), expected)
+
+    def test_trim_clips_last_frames_display_interval(self):
+        duration, frames = self.transcode(trim=(0.0, 5.5))
+        self.assertAlmostEqual(duration, 5.5, places=4)
+        self.assertEqual([at for at, _ in frames], [0, 1, 2, 3, 4])
+
+    def test_whole_cut_inside_one_held_frame(self):
+        duration, frames = self.transcode(trim=(4.75, 5.5))
+        self.assertAlmostEqual(duration, 0.75, places=4)
+        self.assertEqual(len(frames), 1)
+        self.assertEqual(frames[0][0], 0.0)
+        self.assertLess(np.abs(frames[0][1].astype(float) -
+                               dict(inspect(self.source)[1])[4.0]).mean(), 2)
+
+    def test_both_trim_edges_cross_held_intervals(self):
+        duration, frames = self.transcode(trim=(2.5, 3.5), chunk=4, overlap=2)
+        self.assertAlmostEqual(duration, 1.0, places=4)
+        self.assertEqual([at for at, _ in frames], [0, 0.5])
+
+    def test_full_vfr_keeps_timing_and_last_duration(self):
+        expected, original = inspect(self.source)
+        duration, frames = self.transcode(chunk=4, overlap=2)
+        self.assertAlmostEqual(duration, expected, places=4)
+        self.assertEqual([at for at, _ in frames], [at for at, _ in original])
+
+    def test_cfr_trim_chunk_overlap_and_rotation(self):
+        source = self.directory / "phone.mp4"
+        video_file(source, [(i / 24, 20 + i) for i in range(24)], rotation=-90)
+        duration, frames = self.transcode(source, trim=(0.25, 0.75), chunk=4, overlap=2)
+        self.assertAlmostEqual(duration, 0.5, places=4)
+        self.assertEqual(len(frames), 12)
+        self.assertEqual(frames[0][1].shape[:2], (64, 32))
+        self.assertEqual(bench.video_frame(str(source), 0.25).shape[:2], (64, 32))
+
+    def test_past_end_raises_useful_error_without_partial_file(self):
+        before = sorted(self.directory.iterdir())
+        with self.assertRaisesRegex(bench.BenchError, "no frames"):
+            self.transcode(trim=(7.0, 8.0))
+        self.assertEqual(sorted(self.directory.iterdir()), before)
+
+    def test_single_frame_and_trim_past_eof_are_bounded_by_the_file(self):
+        source = self.directory / "one.mp4"
+        video_file(source, [(0, 80)])
+        duration, frames = self.transcode(source, trim=(0.0, 2.0))
+        self.assertAlmostEqual(duration, 1 / 24, places=4)
+        self.assertEqual(len(frames), 1)
+        expected, original = inspect(self.source)
+        duration, frames = self.transcode(trim=(6.0, 20.0))
+        self.assertAlmostEqual(duration, expected - 6, places=4)
+        self.assertEqual(len(frames), 1)
+        np.testing.assert_array_equal(bench.video_frame(str(self.source), 20), original[-1][1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Related to #54, items 4 and 9, including the remaining audio-gap case after #47. This does not reopen the already-fixed main-reel VFR conformance path.

## Problem

The tool bench selects the next decoded picture rather than the picture still being displayed at a VFR trim/preview time. Cuts inside long frame holds can start late, end at the wrong duration, or contain no selected frame. Separately, concatenating decoded audio drops timestamp gaps; the bench also drops initial audio delay.

## Changes

- **`creator/bench.py` / `video_frame`, `_video_window`, `transcode`**: select intersecting display intervals with one-frame lookahead. Clip the first/last holds to the requested window, preserve PTS and packet duration, and keep rotation/chunk overlap processing intact.
- **`creator/mux.py` / `sound_blocks`, `_clip_sound`**: place resampled blocks on the requested sample clock. Stream bounded silence for gaps, trim overlapping/early samples, flush the resampler, and retain small source-timestamp rounding tolerance for continuous PCM.
- The bench shares that audio reader in a separate audio pass, bounded by the written picture, with explicit sample PTS for AAC priming.

**Encoding tradeoff:** the bench disables B-frames (`bf=0`) to keep sparse-VFR MP4 packet/display duration consistent. CRF and preset are unchanged; compression efficiency may change. The main reel's `conform()` implementation is untouched.

## Validation

`test_bench_timestamps.py` (8 methods) and `test_audio_timestamps.py` (7 methods) use actual synthetic media, PyAV encoding/decoding, and identity image processing. They cover VFR held intervals, fractional cuts, CFR/rotation/chunks, delayed/gapped/overlapping audio, mono resampling and flush, coarse timestamp rounding, and multiple reel parts. Existing mux, VFR-seam and bench suites also pass.

**Boundary:** real CPU media IO, not neural upscaling/interpolation, H3 generation, or validation of every user codec. No claim about model-generated shot continuity is made.
