### PR TITLE
Keep neural detail edits inside their masks

### DIFF
--- a/creator/mlxdlss/__init__.py
+++ b/creator/mlxdlss/__init__.py
@@ -2,8 +2,8 @@
 
 Upstream: <https://github.com/iamwavecut/MLX-DLSS>, Apache-2.0,
 revision `7debaaf` (2026-09-05). Its LICENSE and NOTICE sit beside this file.
-Every line in the other modules here is upstream's; `tools/vendor_mlxdlss.py`
-copies them and holds any local edit as a patch.
+`tools/vendor_mlxdlss.py` copies the upstream modules and reapplies the local
+mask-boundary correction recorded in `tools/mlxdlss.patch`.
 
 **Why this is copied and not installed.** The first version of the refiner
 asked the user to `pip install` the port from a git URL, and that was the

--- a/creator/mlxdlss/composition.py
+++ b/creator/mlxdlss/composition.py
@@ -39,6 +39,16 @@ def gaussian_kernel(sigma: float) -> np.ndarray:
     return kernel / kernel.sum()
 
 
+def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray,
+               intensity: float = 1.0) -> np.ndarray:
+    """Apply the red-channel editing boundary once, after spatial filtering."""
+    mask = np.asarray(control_mask, dtype=np.float32)
+    if mask.shape != source.shape or output.shape != source.shape:
+        raise ValueError("control mask and output must match the source image shape")
+    blend = np.clip(mask[..., :1] * np.float32(intensity), 0, 1)
+    return np.clip(source + blend * (output - source), 0, 1).astype(np.float32)
+
+
 def blur(plane: np.ndarray, kernel: np.ndarray) -> np.ndarray:
     """Separable convolution with edge replication (vImage kvImageEdgeExtend)."""
     extent = (len(kernel) - 1) // 2

--- a/creator/mlxdlss/composition.py
+++ b/creator/mlxdlss/composition.py
@@ -39,13 +39,12 @@ def gaussian_kernel(sigma: float) -> np.ndarray:
     return kernel / kernel.sum()
 
 
-def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray,
-               intensity: float = 1.0) -> np.ndarray:
+def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray) -> np.ndarray:
     """Apply the red-channel editing boundary once, after spatial filtering."""
     mask = np.asarray(control_mask, dtype=np.float32)
     if mask.shape != source.shape or output.shape != source.shape:
         raise ValueError("control mask and output must match the source image shape")
-    blend = np.clip(mask[..., :1] * np.float32(intensity), 0, 1)
+    blend = np.clip(mask[..., :1], 0, 1)
     return np.clip(source + blend * (output - source), 0, 1).astype(np.float32)
 
 

--- a/creator/mlxdlss/pipeline.py
+++ b/creator/mlxdlss/pipeline.py
@@ -16,7 +16,7 @@ import numpy as np
 import torch
 
 from . import model as reference
-from .composition import compose_detail, compose_head, resample
+from .composition import blend_mask, compose_detail, compose_head, resample
 from .features import PROFILES, AutomaticMask, NetworkGeometry, make_features
 
 PRECISIONS = ("reference", "fast")
@@ -180,14 +180,20 @@ class NeuralRenderingPipeline:
     ) -> EnhanceResult:
         """Compose the head over the frame, resample back and apply the detail/colour split."""
         started = time.perf_counter()
+        mask = prepared.control_mask
         composed = compose_head(
-            prepared.geometry.crop(head), prepared.processing, control_mask=prepared.control_mask, intensity=intensity
+            prepared.geometry.crop(head), prepared.processing,
+            intensity=intensity if mask is None else 1.0
         )
         if composed.shape[:2] != prepared.source.shape[:2]:
             composed = resample(composed, prepared.source.shape[1], prepared.source.shape[0])
         output = compose_detail(
             prepared.source, composed, detail_strength=detail_strength, colour_strength=colour_strength, radius=detail_radius
         )
+        if mask is not None:
+            # Filtering an already masked residual spreads the change outside
+            # the mask. Filter first, then blend once (also for soft masks).
+            output = blend_mask(prepared.source, output, mask, intensity)
         timings = {
             "preprocess": prepared.preprocess_seconds,
             "network": network_seconds,

--- a/creator/mlxdlss/pipeline.py
+++ b/creator/mlxdlss/pipeline.py
@@ -183,7 +183,7 @@ class NeuralRenderingPipeline:
         mask = prepared.control_mask
         composed = compose_head(
             prepared.geometry.crop(head), prepared.processing,
-            intensity=intensity if mask is None else 1.0
+            intensity=intensity
         )
         if composed.shape[:2] != prepared.source.shape[:2]:
             composed = resample(composed, prepared.source.shape[1], prepared.source.shape[0])
@@ -192,8 +192,9 @@ class NeuralRenderingPipeline:
         )
         if mask is not None:
             # Filtering an already masked residual spreads the change outside
-            # the mask. Filter first, then blend once (also for soft masks).
-            output = blend_mask(prepared.source, output, mask, intensity)
+            # the mask. Filter first, then mask once (also for soft masks).
+            # Intensity stays before detail/clipping, matching unmasked runs.
+            output = blend_mask(prepared.source, output, mask)
         timings = {
             "preprocess": prepared.preprocess_seconds,
             "network": network_seconds,

--- a/creator/mlxdlss/temporal.py
+++ b/creator/mlxdlss/temporal.py
@@ -14,7 +14,7 @@ from typing import Callable
 
 import numpy as np
 
-from .composition import compose_detail, compose_head
+from .composition import blend_mask, compose_detail, compose_head
 from .features import PROFILES, AutomaticMask, NetworkGeometry, deterministic_noise, half, make_features, scaled_color
 
 BLEND_SCALE = 0.73974609375  # half(blend_scale) of the recovered package
@@ -270,21 +270,29 @@ class TemporalSession:
         height, width = frame.shape[:2]
         geometry = NetworkGeometry.vendor_aligned(width, height)
         controls = self._controls()
+        intensity = self.options.intensity if control_mask is None else 1.0
         if self.history is None:
             network = make_features(frame, frame_index=self.frame_index, geometry=geometry, control_mask=control_mask, **controls)
             head = geometry.crop(self.pipeline.run_features(network))
-            output = compose_head(head, frame, control_mask=control_mask, intensity=self.options.intensity)
+            output = compose_head(head, frame, intensity=intensity)
         else:
             if motion is None:
                 motion = self.motion(frame, self.previous)
             features = make_temporal_features(frame, self.history, motion, frame_index=self.frame_index, control_mask=control_mask, **controls)
             network = extend_features(features, geometry, self.frame_index)
             head = geometry.crop(self.pipeline.run_features(network))
-            output = compose_temporal(head, frame, features, blend_scale=self.options.blend_scale, control_mask=control_mask, intensity=self.options.intensity)
-        self.history = output; self.previous = frame; self.frame_index += 1
-        return compose_detail(
+            output = compose_temporal(head, frame, features, blend_scale=self.options.blend_scale, intensity=intensity)
+        # History keeps the original masked head recipe, before detail/colour;
+        # the displayed result applies that mask after filtering instead. This
+        # preserves unedited pixels without multiplying soft-mask strength twice.
+        self.history = (output if control_mask is None else
+                        blend_mask(frame, output, control_mask, self.options.intensity))
+        self.previous = frame; self.frame_index += 1
+        detailed = compose_detail(
             frame, output, detail_strength=self.options.detail_strength, colour_strength=self.options.colour_strength, radius=self.options.detail_radius
         )
+        return (detailed if control_mask is None else
+                blend_mask(frame, detailed, control_mask, self.options.intensity))
 
     def _is_scene_cut(self, frame: np.ndarray) -> bool:
         if self.options.scene_cut_threshold <= 0:

--- a/creator/mlxdlss/temporal.py
+++ b/creator/mlxdlss/temporal.py
@@ -270,7 +270,7 @@ class TemporalSession:
         height, width = frame.shape[:2]
         geometry = NetworkGeometry.vendor_aligned(width, height)
         controls = self._controls()
-        intensity = self.options.intensity if control_mask is None else 1.0
+        intensity = self.options.intensity
         if self.history is None:
             network = make_features(frame, frame_index=self.frame_index, geometry=geometry, control_mask=control_mask, **controls)
             head = geometry.crop(self.pipeline.run_features(network))
@@ -286,13 +286,13 @@ class TemporalSession:
         # the displayed result applies that mask after filtering instead. This
         # preserves unedited pixels without multiplying soft-mask strength twice.
         self.history = (output if control_mask is None else
-                        blend_mask(frame, output, control_mask, self.options.intensity))
+                        blend_mask(frame, output, control_mask))
         self.previous = frame; self.frame_index += 1
         detailed = compose_detail(
             frame, output, detail_strength=self.options.detail_strength, colour_strength=self.options.colour_strength, radius=self.options.detail_radius
         )
         return (detailed if control_mask is None else
-                blend_mask(frame, detailed, control_mask, self.options.intensity))
+                blend_mask(frame, detailed, control_mask))
 
     def _is_scene_cut(self, frame: np.ndarray) -> bool:
         if self.options.scene_cut_threshold <= 0:

--- a/tests/test_neural_mask_boundary.py
+++ b/tests/test_neural_mask_boundary.py
@@ -1,0 +1,64 @@
+"""The final DLSS colour/detail recipe must obey the mask, not just its head.
+
+CPU-only production composition and temporal sessions; a deterministic head
+stands in for the network. No downloaded weights or GPU are used.
+"""
+
+import numpy as np
+
+import layout
+from harness import check
+
+port = layout.load("mlxdlss").mlxdlss
+source = np.full((64, 64, 3), 0.5, dtype=np.float32)
+mask = np.ones_like(source)
+mask[:, :32] = 0
+soft = np.full_like(source, 0.25)
+
+
+class Network:
+    def run_features(self, features):
+        out = np.full((*features.shape[:2], 4), 0.4, dtype=np.float32)
+        out[..., 3] = 0
+        return out
+
+
+pipeline = object.__new__(port.NeuralRenderingPipeline)
+pipeline.run_features = Network().run_features
+
+
+def still(control, detail, colour, intensity=1):
+    prepared = pipeline.prepare(source, control_mask=control)
+    return pipeline.finish(prepared, pipeline.run_features(prepared.features),
+                           detail_strength=detail, colour_strength=colour,
+                           intensity=intensity).image
+
+
+for detail, colour in [(1.25, 0), (1, 1), (0.5, 1.5)]:
+    out = still(mask, detail, colour)
+    check(f"still {detail}/{colour}: zero mask is exact source",
+          np.array_equal(out[:, :32], source[:, :32]), True)
+    raw = still(None, detail, colour)
+    soft_out = still(soft, detail, colour)
+    check(f"still {detail}/{colour}: fractional mask applied once",
+          np.allclose(soft_out, source + 0.25 * (raw - source), atol=1e-6), True)
+    check("zero intensity is exact source",
+          np.array_equal(still(mask, detail, colour, 0), source), True)
+
+    options = port.TemporalOptions(detail_strength=detail, colour_strength=colour,
+                                   scene_cut_threshold=0)
+    sequence = port.TemporalSession(Network(), options=options, motion="zero")
+    for frame_index in range(3):
+        out = sequence.process(source, control_mask=mask)
+        check(f"temporal {detail}/{colour} frame {frame_index}: outside unchanged",
+              np.array_equal(out[:, :32], source[:, :32]), True)
+        check("temporal history outside is also source",
+              np.array_equal(sequence.history[:, :32], source[:, :32]), True)
+
+    # The first temporal frame and still path share the same mask semantics.
+    sequence = port.TemporalSession(Network(), options=options, motion="zero")
+    check("soft mask first temporal frame equals still",
+          np.allclose(sequence.process(source, control_mask=soft), soft_out, atol=1e-6), True)
+
+check("fully masked still remains the original recipe",
+      np.allclose(still(np.ones_like(source), 1.25, 0), still(None, 1.25, 0), atol=1e-6), True)

--- a/tests/test_neural_mask_boundary.py
+++ b/tests/test_neural_mask_boundary.py
@@ -17,8 +17,11 @@ soft = np.full_like(source, 0.25)
 
 
 class Network:
+    def __init__(self, head=0.4):
+        self.head = head
+
     def run_features(self, features):
-        out = np.full((*features.shape[:2], 4), 0.4, dtype=np.float32)
+        out = np.full((*features.shape[:2], 4), self.head, dtype=np.float32)
         out[..., 3] = 0
         return out
 
@@ -62,3 +65,25 @@ for detail, colour in [(1.25, 0), (1, 1), (0.5, 1.5)]:
 
 check("fully masked still remains the original recipe",
       np.allclose(still(np.ones_like(source), 1.25, 0), still(None, 1.25, 0), atol=1e-6), True)
+
+# Intensity belongs before detail/colour clipping, just as in unmasked runs.
+# Moving it into the final mask blend changes saturated highlights/shadows.
+for level, residual in [(0.95, 0.4), (0.05, -0.4)]:
+    source = np.full_like(source, level)
+    network = Network(residual)
+    pipeline.run_features = network.run_features
+    for intensity in (0, 0.25, 0.5, 1):
+        raw = still(None, 1.25, 1.5, intensity)
+        check(f"saturated still {level}/{intensity}: white mask preserves recipe",
+              np.allclose(still(np.ones_like(source), 1.25, 1.5, intensity), raw, atol=1e-6), True)
+        check(f"saturated still {level}/{intensity}: soft mask is applied once",
+              np.allclose(still(soft, 1.25, 1.5, intensity),
+                          source + 0.25 * (raw - source), atol=1e-6), True)
+        options = port.TemporalOptions(detail_strength=1.25, colour_strength=1.5,
+                                       intensity=intensity, scene_cut_threshold=0)
+        masked = port.TemporalSession(network, options=options, motion="zero")
+        unmasked = port.TemporalSession(network, options=options, motion="zero")
+        for frame_index in range(3):
+            check(f"saturated temporal {level}/{intensity}/{frame_index}: white mask preserves recipe",
+                  np.allclose(masked.process(source, control_mask=np.ones_like(source)),
+                              unmasked.process(source), atol=1e-6), True)

--- a/tools/mlxdlss.patch
+++ b/tools/mlxdlss.patch
@@ -1,0 +1,103 @@
+diff --git a/creator/mlxdlss/composition.py b/creator/mlxdlss/composition.py
+index 8a4bcf2..ab41e78 100644
+--- a/creator/mlxdlss/composition.py
++++ b/creator/mlxdlss/composition.py
+@@ -39,6 +39,16 @@ def gaussian_kernel(sigma: float) -> np.ndarray:
+     return kernel / kernel.sum()
+ 
+ 
++def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray,
++               intensity: float = 1.0) -> np.ndarray:
++    """Apply the red-channel editing boundary once, after spatial filtering."""
++    mask = np.asarray(control_mask, dtype=np.float32)
++    if mask.shape != source.shape or output.shape != source.shape:
++        raise ValueError("control mask and output must match the source image shape")
++    blend = np.clip(mask[..., :1] * np.float32(intensity), 0, 1)
++    return np.clip(source + blend * (output - source), 0, 1).astype(np.float32)
++
++
+ def blur(plane: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+     """Separable convolution with edge replication (vImage kvImageEdgeExtend)."""
+     extent = (len(kernel) - 1) // 2
+diff --git a/creator/mlxdlss/pipeline.py b/creator/mlxdlss/pipeline.py
+index 9ff3b25..d7904b5 100644
+--- a/creator/mlxdlss/pipeline.py
++++ b/creator/mlxdlss/pipeline.py
+@@ -16,7 +16,7 @@ import numpy as np
+ import torch
+ 
+ from . import model as reference
+-from .composition import compose_detail, compose_head, resample
++from .composition import blend_mask, compose_detail, compose_head, resample
+ from .features import PROFILES, AutomaticMask, NetworkGeometry, make_features
+ 
+ PRECISIONS = ("reference", "fast")
+@@ -180,14 +180,20 @@ class NeuralRenderingPipeline:
+     ) -> EnhanceResult:
+         """Compose the head over the frame, resample back and apply the detail/colour split."""
+         started = time.perf_counter()
++        mask = prepared.control_mask
+         composed = compose_head(
+-            prepared.geometry.crop(head), prepared.processing, control_mask=prepared.control_mask, intensity=intensity
++            prepared.geometry.crop(head), prepared.processing,
++            intensity=intensity if mask is None else 1.0
+         )
+         if composed.shape[:2] != prepared.source.shape[:2]:
+             composed = resample(composed, prepared.source.shape[1], prepared.source.shape[0])
+         output = compose_detail(
+             prepared.source, composed, detail_strength=detail_strength, colour_strength=colour_strength, radius=detail_radius
+         )
++        if mask is not None:
++            # Filtering an already masked residual spreads the change outside
++            # the mask. Filter first, then blend once (also for soft masks).
++            output = blend_mask(prepared.source, output, mask, intensity)
+         timings = {
+             "preprocess": prepared.preprocess_seconds,
+             "network": network_seconds,
+diff --git a/creator/mlxdlss/temporal.py b/creator/mlxdlss/temporal.py
+index bd64d05..63ffe11 100644
+--- a/creator/mlxdlss/temporal.py
++++ b/creator/mlxdlss/temporal.py
+@@ -14,7 +14,7 @@ from typing import Callable
+ 
+ import numpy as np
+ 
+-from .composition import compose_detail, compose_head
++from .composition import blend_mask, compose_detail, compose_head
+ from .features import PROFILES, AutomaticMask, NetworkGeometry, deterministic_noise, half, make_features, scaled_color
+ 
+ BLEND_SCALE = 0.73974609375  # half(blend_scale) of the recovered package
+@@ -270,21 +270,29 @@ class TemporalSession:
+         height, width = frame.shape[:2]
+         geometry = NetworkGeometry.vendor_aligned(width, height)
+         controls = self._controls()
++        intensity = self.options.intensity if control_mask is None else 1.0
+         if self.history is None:
+             network = make_features(frame, frame_index=self.frame_index, geometry=geometry, control_mask=control_mask, **controls)
+             head = geometry.crop(self.pipeline.run_features(network))
+-            output = compose_head(head, frame, control_mask=control_mask, intensity=self.options.intensity)
++            output = compose_head(head, frame, intensity=intensity)
+         else:
+             if motion is None:
+                 motion = self.motion(frame, self.previous)
+             features = make_temporal_features(frame, self.history, motion, frame_index=self.frame_index, control_mask=control_mask, **controls)
+             network = extend_features(features, geometry, self.frame_index)
+             head = geometry.crop(self.pipeline.run_features(network))
+-            output = compose_temporal(head, frame, features, blend_scale=self.options.blend_scale, control_mask=control_mask, intensity=self.options.intensity)
+-        self.history = output; self.previous = frame; self.frame_index += 1
+-        return compose_detail(
++            output = compose_temporal(head, frame, features, blend_scale=self.options.blend_scale, intensity=intensity)
++        # History keeps the original masked head recipe, before detail/colour;
++        # the displayed result applies that mask after filtering instead. This
++        # preserves unedited pixels without multiplying soft-mask strength twice.
++        self.history = (output if control_mask is None else
++                        blend_mask(frame, output, control_mask, self.options.intensity))
++        self.previous = frame; self.frame_index += 1
++        detailed = compose_detail(
+             frame, output, detail_strength=self.options.detail_strength, colour_strength=self.options.colour_strength, radius=self.options.detail_radius
+         )
++        return (detailed if control_mask is None else
++                blend_mask(frame, detailed, control_mask, self.options.intensity))
+ 
+     def _is_scene_cut(self, frame: np.ndarray) -> bool:
+         if self.options.scene_cut_threshold <= 0:

--- a/tools/mlxdlss.patch
+++ b/tools/mlxdlss.patch
@@ -1,18 +1,17 @@
 diff --git a/creator/mlxdlss/composition.py b/creator/mlxdlss/composition.py
-index 8a4bcf2..ab41e78 100644
+index 8a4bcf2..820f248 100644
 --- a/creator/mlxdlss/composition.py
 +++ b/creator/mlxdlss/composition.py
-@@ -39,6 +39,16 @@ def gaussian_kernel(sigma: float) -> np.ndarray:
+@@ -39,6 +39,15 @@ def gaussian_kernel(sigma: float) -> np.ndarray:
      return kernel / kernel.sum()
  
  
-+def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray,
-+               intensity: float = 1.0) -> np.ndarray:
++def blend_mask(source: np.ndarray, output: np.ndarray, control_mask: np.ndarray) -> np.ndarray:
 +    """Apply the red-channel editing boundary once, after spatial filtering."""
 +    mask = np.asarray(control_mask, dtype=np.float32)
 +    if mask.shape != source.shape or output.shape != source.shape:
 +        raise ValueError("control mask and output must match the source image shape")
-+    blend = np.clip(mask[..., :1] * np.float32(intensity), 0, 1)
++    blend = np.clip(mask[..., :1], 0, 1)
 +    return np.clip(source + blend * (output - source), 0, 1).astype(np.float32)
 +
 +
@@ -20,7 +19,7 @@ index 8a4bcf2..ab41e78 100644
      """Separable convolution with edge replication (vImage kvImageEdgeExtend)."""
      extent = (len(kernel) - 1) // 2
 diff --git a/creator/mlxdlss/pipeline.py b/creator/mlxdlss/pipeline.py
-index 9ff3b25..d7904b5 100644
+index 9ff3b25..4020678 100644
 --- a/creator/mlxdlss/pipeline.py
 +++ b/creator/mlxdlss/pipeline.py
 @@ -16,7 +16,7 @@ import numpy as np
@@ -32,7 +31,7 @@ index 9ff3b25..d7904b5 100644
  from .features import PROFILES, AutomaticMask, NetworkGeometry, make_features
  
  PRECISIONS = ("reference", "fast")
-@@ -180,14 +180,20 @@ class NeuralRenderingPipeline:
+@@ -180,14 +180,21 @@ class NeuralRenderingPipeline:
      ) -> EnhanceResult:
          """Compose the head over the frame, resample back and apply the detail/colour split."""
          started = time.perf_counter()
@@ -40,7 +39,7 @@ index 9ff3b25..d7904b5 100644
          composed = compose_head(
 -            prepared.geometry.crop(head), prepared.processing, control_mask=prepared.control_mask, intensity=intensity
 +            prepared.geometry.crop(head), prepared.processing,
-+            intensity=intensity if mask is None else 1.0
++            intensity=intensity
          )
          if composed.shape[:2] != prepared.source.shape[:2]:
              composed = resample(composed, prepared.source.shape[1], prepared.source.shape[0])
@@ -49,13 +48,14 @@ index 9ff3b25..d7904b5 100644
          )
 +        if mask is not None:
 +            # Filtering an already masked residual spreads the change outside
-+            # the mask. Filter first, then blend once (also for soft masks).
-+            output = blend_mask(prepared.source, output, mask, intensity)
++            # the mask. Filter first, then mask once (also for soft masks).
++            # Intensity stays before detail/clipping, matching unmasked runs.
++            output = blend_mask(prepared.source, output, mask)
          timings = {
              "preprocess": prepared.preprocess_seconds,
              "network": network_seconds,
 diff --git a/creator/mlxdlss/temporal.py b/creator/mlxdlss/temporal.py
-index bd64d05..63ffe11 100644
+index bd64d05..84ab9f4 100644
 --- a/creator/mlxdlss/temporal.py
 +++ b/creator/mlxdlss/temporal.py
 @@ -14,7 +14,7 @@ from typing import Callable
@@ -71,7 +71,7 @@ index bd64d05..63ffe11 100644
          height, width = frame.shape[:2]
          geometry = NetworkGeometry.vendor_aligned(width, height)
          controls = self._controls()
-+        intensity = self.options.intensity if control_mask is None else 1.0
++        intensity = self.options.intensity
          if self.history is None:
              network = make_features(frame, frame_index=self.frame_index, geometry=geometry, control_mask=control_mask, **controls)
              head = geometry.crop(self.pipeline.run_features(network))
@@ -91,13 +91,13 @@ index bd64d05..63ffe11 100644
 +        # the displayed result applies that mask after filtering instead. This
 +        # preserves unedited pixels without multiplying soft-mask strength twice.
 +        self.history = (output if control_mask is None else
-+                        blend_mask(frame, output, control_mask, self.options.intensity))
++                        blend_mask(frame, output, control_mask))
 +        self.previous = frame; self.frame_index += 1
 +        detailed = compose_detail(
              frame, output, detail_strength=self.options.detail_strength, colour_strength=self.options.colour_strength, radius=self.options.detail_radius
          )
 +        return (detailed if control_mask is None else
-+                blend_mask(frame, detailed, control_mask, self.options.intensity))
++                blend_mask(frame, detailed, control_mask))
  
      def _is_scene_cut(self, frame: np.ndarray) -> bool:
          if self.options.scene_cut_threshold <= 0:


### PR DESCRIPTION
Related to #54, item 10.

## Problem

The neural output is masked before spatial detail composition. Subsequent filtering can spread the change outside a hard edit mask. Applying a second mask naively would instead multiply soft-mask strength twice.

## Changes

- **`creator/mlxdlss/composition.py`**: add one final source/output mask blend.
- **`creator/mlxdlss/pipeline.py`**: compose the masked result's head/detail before applying its mask exactly once at the output boundary. Intensity remains before detail/clipping, as in the unmasked path; a full-white mask must not change saturated highlights/shadows.
- **`creator/mlxdlss/temporal.py`**: use the same final display boundary while keeping temporal history on the original pre-detail masked-head contract. Control-mask feature channels are still passed to inference.
- **`tools/mlxdlss.patch`** records the local vendored delta for the existing re-vendor helper; the package note documents that delta.

Unmasked rendering keeps its existing path. This does not change weights or claim to recover missing image details.

## Validation

New `test_neural_mask_boundary.py` exercises the production first-frame and temporal composition paths with deterministic fake model heads: exact outside-mask preservation, fractional masks applied once, zero/fractional intensity, saturated highlights/shadows, several contrast/detail combinations, history boundaries, and all-one-mask/unmasked controls. It reproduced failures before the change and passes afterward. The existing vendor suite and patch applicability check pass.

**Boundary:** CPU composition tests with fake network output, not DLL-derived weights or GPU perceptual testing.
