### PR TITLE
Freeze Blockout exports before asynchronous work

### DIFF
--- a/tests/test_blockout_snapshot.py
+++ b/tests/test_blockout_snapshot.py
@@ -1,0 +1,92 @@
+"""A Blockout run is one scene, even while the live bench is edited.
+
+    python3 tests/test_blockout_snapshot.py
+
+Exercises the real run/path/raster code, replacing only DOM, PNG encoding and
+HTTP. Frame checksums and the submitted sidecar must match an unedited control.
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const url = pathToFileURL(path.join(process.cwd(), "web/creator/blockout.js"));
+const source = readFileSync(url, "utf8").replace("class Bench {", "export class Bench {")
+  .replace(/from "(\.[^"]+)"/g, (_, spec) => `from "${new URL(spec, url).href}"`);
+const { Bench } = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+const { api } = await import("./../scripts/api.js");
+let written, uploaded, active, mutate, captures;
+api.fetchApi = async (route, options) => {
+  if (route.endsWith("/write")) written = JSON.parse(options.body);
+  if (route === "/upload/image") uploaded = options.body.get("image").name;
+  return { ok: true, json: async () => route.endsWith("/write")
+    ? { path: "continuity/blockout/test.mp4", kind: "video" }
+    : route === "/upload/image" ? { name: uploaded, subfolder: "continuity/blockout" } : { held: 24 } };
+};
+NodeClass.prototype.getContext = function () {
+  const canvas = this;
+  return { createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
+    putImageData: (image) => { canvas.rgba = Array.from(image.data); } };
+};
+NodeClass.prototype.toBlob = function (callback) {
+  captures.push(this.rgba.reduce((sum, value) => sum + value, 0));
+  if (captures.length === 1 && mutate) {
+    assert.equal(active.busy, true);
+    active.setPass("lines");
+    active.marks.forEach((mark) => { mark.x += 8; });
+    active.shot.x += 8;
+    active.objects.forEach((piece) => { piece.x += 8; piece.word = "changed object"; });
+    active.setDuration(2);
+    active.aspect = "1:1";
+  }
+  queueMicrotask(() => callback(new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" })));
+};
+async function sample(edit, still = false) {
+  written = null; uploaded = null; captures = []; mutate = edit;
+  const bench = active = new Bench({}, () => {});
+  bench.overlay = { isConnected: false };
+  for (const name of ["paintBench", "paintBox", "paint", "paintResult", "paintFoot"]) bench[name] = () => {};
+  bench.frameSize = () => ({ w: 32, h: 18 });
+  bench.setDuration(1);
+  bench.addPiece("box");
+  bench.objects[0].word = "original object";
+  bench.marks = still ? [] : [{ ...bench.shot, x: 0 }, { ...bench.shot, x: 1 }];
+  const originalScene = bench.scene();
+  const originalWords = bench.said();
+  const originalPass = { ...bench.passOf() };
+  await bench.run();
+  assert.equal(bench.error, null);
+  return { frames: captures, written, uploaded, result: bench.result,
+    originalScene, originalWords, originalPass, busy: bench.busy };
+}
+const control = await sample(false);
+const edited = await sample(true);
+assert.equal(control.frames.length, 24);
+assert.deepEqual(edited.frames, control.frames, "mid-run edits must not change later frame pixels");
+assert.deepEqual(edited.written.scene, control.written.scene, "sidecar describes the rendered snapshot");
+assert.equal(edited.written.op, "depth");
+assert.equal(control.result.words, control.originalWords);
+assert.equal(control.result.opId, control.originalPass.opId);
+assert.equal(edited.result, null, "old run cannot reopen attachment doors for the edited scene");
+assert.equal(edited.busy, false);
+const stillControl = await sample(false, true);
+const stillEdited = await sample(true, true);
+assert.deepEqual(stillEdited.frames, stillControl.frames);
+assert.equal(stillEdited.uploaded, "blockout-depth.png", "still filename belongs to the rendered pass");
+assert.equal(stillControl.result.words, stillControl.originalWords);
+assert.equal(stillEdited.result, null);
+console.log(JSON.stringify({ frames: control.frames.length, cases: 4 }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("one-second guide", result["frames"], 24)
+check("still and video snapshot controls", result["cases"], 4)

--- a/web/creator/blockout.js
+++ b/web/creator/blockout.js
@@ -955,6 +955,7 @@ class Bench {
     this.progress = null;      // a sentence for the run button while it works
     this.error = null;
     this.result = null;
+    this.revision = 0;        // edits made while a run is yielding to the page
     this.sentTo = new Set();
     this.sending = null;
 
@@ -1684,6 +1685,7 @@ class Bench {
    *  dial on the tracing bench — and note what is *not* here: flying the free
    *  camera changes nothing about the file, and so stales nothing. */
   markStale() {
+    this.revision++;
     if (!this.result) return;
     this.result = null;
     this.sentTo.clear();
@@ -2605,26 +2607,31 @@ class Bench {
     };
     try {
       const { w, h } = this.frameSize();
-      // The set, as it stands at the press. The run yields to the page between
-      // frames — that is what keeps the room responsive — so without this a
-      // piece dragged mid-render would change sets halfway through the clip.
+      // Freeze the whole job, not just its objects. Encoding/uploading yields
+      // between frames, while the camera marks, pass and prose remain editable.
+      // The sidecar must describe the same scene the pixels were drawn from.
+      const revision = this.revision;
+      const scene = this.scene();
+      const pass = this.passOf();
+      const words = this.said();
       const staged = this.objects.map((piece) => ({ ...piece }));
-      const still = this.marks.length < 2;
+      const still = scene.marks.length < 2;
+      let result;
       if (still) {
         step(t("Tracing the frame…"));
-        const blob = await this.drawFull(w, h, this.shot, staged);
+        const blob = await this.drawFull(w, h, scene.shot, staged, scene.pass);
         const asset = await upload(
-          new File([blob], `blockout-${this.pass}.png`, { type: "image/png" }), WRITES.slice(0, -1));
-        this.result = { path: asset.path, kind: "image" };
+          new File([blob], `blockout-${scene.pass}.png`, { type: "image/png" }), WRITES.slice(0, -1));
+        result = { path: asset.path, kind: "image" };
       } else {
         const token = crypto.getRandomValues(new Uint32Array(4))
           .reduce((hex, part) => hex + part.toString(16).padStart(8, "0"), "");
-        const count = Math.max(2, Math.round(this.duration * FPS));
+        const count = Math.max(2, Math.round(scene.duration * FPS));
         let batch = [];
         for (let index = 0; index < count; index++) {
           step(t("Drawing frame {n} of {count}…", { n: index + 1, count }));
-          const cam = pathCam(this.marks, index / (count - 1));
-          batch.push({ index, blob: await this.drawFull(w, h, cam, staged) });
+          const cam = pathCam(scene.marks, index / (count - 1));
+          batch.push({ index, blob: await this.drawFull(w, h, cam, staged, scene.pass) });
           if (batch.length >= BATCH || index === count - 1) {
             step(t("Sending frame {n} of {count}…", { n: index + 1, count }));
             await blockoutFrames(token, batch);
@@ -2632,16 +2639,18 @@ class Bench {
           }
         }
         step(t("Writing the clip…"));
-        this.result = await blockoutWrite({
-          token, fps: FPS, op: this.pass, scene: this.scene(),
+        result = await blockoutWrite({
+          token, fps: FPS, op: scene.pass, scene,
         });
       }
-      const pass = this.passOf();
-      this.result.op = pass.label;
-      this.result.opId = pass.opId;
+      result.op = pass.label;
+      result.opId = pass.opId;
       // The prose, stamped on the file's record: staging and move together, so
       // a door's take() — and anything later that wants the words — has them.
-      this.result.words = this.said();
+      result.words = words;
+      // A finished old snapshot remains in the picker, but it must not reopen
+      // the attachment doors after an edit has made the live scene different.
+      if (this.revision === revision) this.result = result;
     } catch (error) {
       this.error = String(error.message || error);
     }
@@ -2651,7 +2660,7 @@ class Bench {
   }
 
   /** One frame at the run's size, as a PNG blob. */
-  drawFull(width, height, cam, staged = this.objects) {
+  drawFull(width, height, cam, staged = this.objects, pass = this.pass) {
     if (!this.full || this.full.w !== width || this.full.h !== height) {
       this.full = new Raster(width, height);
       this.fullCanvas = el("canvas");
@@ -2660,7 +2669,7 @@ class Bench {
       this.fullContext = this.fullCanvas.getContext("2d");
     }
     this.full.raster(staged, cam);
-    this.full.shade(this.fullContext, this.pass);
+    this.full.shade(this.fullContext, pass);
     return new Promise((resolve, reject) => {
       this.fullCanvas.toBlob((blob) =>
         blob ? resolve(blob) : reject(new Error(t("a frame could not be encoded"))), "image/png");


### PR DESCRIPTION
Related to #54, item 11.

## Problem

A Blockout export yields while drawing/uploading frames. Only the objects were frozen; live edits to camera marks, render pass, duration or prose could change later frames or make the saved sidecar describe a different scene.

## Changes

**`web/creator/blockout.js`** freezes the complete job at the Run gesture: dimensions, scene/cameras, objects, pass, duration and words. Both still/video drawing and metadata use that snapshot. A revision counter prevents an old result from reopening attachment controls after the user has edited the live scene; the exported file remains available in the picker.

The UI remains editable during export. No in-progress job is silently redirected to the new scene.

## Validation

New `test_blockout_snapshot.py` exercises the real run, camera path and raster code with DOM/PNG/HTTP boundaries substituted. Edits are injected during the first asynchronous frame; all subsequent frame checksums and sidecar data match an unedited control. Still output naming, result prose and stale attachment gating are also covered. Existing Blockout coverage is retained.

**Boundary:** deterministic frontend/raster tests, not an interactive browser recording or downstream GPU generation.
