### PR TITLE
Bind Loupe comparisons to their producer and frame

### DIFF
--- a/creator/neuraltwin.py
+++ b/creator/neuraltwin.py
@@ -50,6 +50,7 @@ BLOB_WIDGETS = {
 # carried across untouched: the question this answers is "with or without",
 # and a twin that also changed the settings would answer a different one.
 BLOCK = "neural"
+PRODUCER_KEY = "continuity_producer"
 
 
 class TwinError(Exception):
@@ -82,7 +83,39 @@ def _blob_nodes(prompt):
     return found
 
 
-def read(prompt):
+def _producer(prompt, producer=None):
+    """Select an explicit producer, or the only unambiguous legacy producer."""
+    nodes = _blob_nodes(prompt)
+    if not nodes:
+        raise TwinError("this file does not carry a prompt this pack can render")
+    if producer is None:
+        if len(nodes) != 1:
+            raise TwinError("this older file has multiple Continuity outputs but no producer metadata; "
+                            "render it once with the updated node before comparing its twin")
+        return nodes[0], 0
+    if not isinstance(producer, dict):
+        raise TwinError("this file's Continuity producer metadata is invalid")
+    index = producer.get("index", 0)
+    if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+        raise TwinError("this file's Continuity image index is invalid")
+    for entry in nodes:
+        if entry[0] == producer.get("node"):
+            return entry, index
+    raise TwinError("this file's Continuity producer is absent from its prompt")
+
+
+def producer_metadata(hidden, index=0):
+    """Name the original producer, not the ephemeral save node's expansion id."""
+    node_id = getattr(hidden, "unique_id", None)
+    dynamic = getattr(hidden, "dynprompt", None)
+    if node_id is not None and dynamic is not None:
+        node_id = dynamic.get_real_node_id(node_id)
+    if any(entry[0] == node_id for entry in _blob_nodes(getattr(hidden, "prompt", None))):
+        return {"node": node_id, "index": index}
+    return None
+
+
+def read(prompt, producer=None):
     """What this render says about the refiner.
 
     `{"ours": bool, "on": bool, "settings": {...}|None, "node": id|None}`.
@@ -91,50 +124,55 @@ def read(prompt):
     prompt in it, or one made by somebody else's graph, has no other version to
     render and has to be offered the tile comparison instead.
     """
-    nodes = _blob_nodes(prompt)
-    if not nodes:
+    if not _blob_nodes(prompt):
         return {"ours": False, "on": False, "settings": None, "node": None}
-    # On if *any* of our nodes asked for it, and the settings are that node's.
-    # Which node wrote the file is not knowable from the prompt — a pre-stage
-    # feeding a creator writes a still and a clip out of one queue — and it
-    # does not need to be: `twin` flips every one of them, so what this has to
-    # answer is whether the refiner is anywhere in what made this file.
-    for node_id, _, blob in nodes:
-        block = blob.get(BLOCK)
-        if isinstance(block, dict) and block.get("on"):
-            return {"ours": True, "on": True, "settings": block, "node": node_id}
-    node_id, _, blob = nodes[0]
+    try:
+        (node_id, _, blob), index = _producer(prompt, producer)
+    except TwinError as error:
+        return {"ours": False, "on": False, "settings": None, "node": None,
+                "error": str(error)}
     block = blob.get(BLOCK)
-    return {"ours": True, "on": False,
-            "settings": block if isinstance(block, dict) else None, "node": node_id}
+    return {"ours": True, "on": bool(isinstance(block, dict) and block.get("on")),
+            "settings": block if isinstance(block, dict) else None, "node": node_id,
+            **({"index": index} if producer is not None else {})}
 
 
-def twin(prompt, on, block=None):
+def twin(prompt, on, block=None, producer=None):
     """The same prompt with the refiner switched `on` or off. -> a new prompt.
 
-    Every node of ours is flipped, not only the last: a still that a piece is
-    built on is refined by its own pre-stage, and a comparison that left one of
-    the two on would be comparing two things that differ in two ways.
+    Only the file's producer is flipped. Changing an independent Creator (or
+    the PreStage that supplies an input) would compare two different sources,
+    not the same render with its final material pass switched off or on.
 
     `block` replaces the settings while switching *on* — which is what lets the
     dials on a viewer's rail mean something for a render that never had the
     pass. Switching off ignores it: there is nothing to set.
     """
-    nodes = _blob_nodes(prompt)
-    if not nodes:
-        raise TwinError("this file does not carry a prompt this pack can render")
+    (node_id, widget, blob), _ = _producer(prompt, producer)
     twinned = copy.deepcopy(prompt)
-    for node_id, widget, blob in nodes:
-        current = blob.get(BLOCK) if isinstance(blob.get(BLOCK), dict) else {}
-        if on:
-            wanted = {**current, **(block or {}), "on": True}
-        else:
-            # Written as off rather than deleted: a blob that never had the key
-            # is a blob from before the refiner existed, and adding an explicit
-            # off to it says the same thing in the shape this build reads.
-            wanted = {**current, "on": False}
-        blob = {**blob, BLOCK: wanted}
-        twinned[node_id] = {**twinned[node_id],
-                            "inputs": {**twinned[node_id]["inputs"],
-                                       widget: json.dumps(blob)}}
+    current = blob.get(BLOCK) if isinstance(blob.get(BLOCK), dict) else {}
+    wanted = {**current, **(block or {}), "on": True} if on else {**current, "on": False}
+    blob = {**blob, BLOCK: wanted}
+    twinned[node_id] = {**twinned[node_id],
+                       "inputs": {**twinned[node_id]["inputs"], widget: json.dumps(blob)}}
     return twinned
+
+
+def dependency_prompt(prompt, node_id):
+    """Keep the target's input closure under unchanged ids, excluding other outputs.
+
+    A whole saved prompt can include an unrelated output with missing models.
+    It must neither run nor prevent this comparison from validating.
+    """
+    held, pending = set(), [node_id]
+    while pending:
+        current = pending.pop()
+        if current in held or current not in prompt:
+            continue
+        held.add(current)
+        for value in (prompt[current].get("inputs") or {}).values():
+            if (isinstance(value, list) and len(value) == 2
+                    and isinstance(value[0], str) and isinstance(value[1], int)
+                    and value[0] in prompt):
+                pending.append(value[0])
+    return {key: copy.deepcopy(value) for key, value in prompt.items() if key in held}

--- a/creator/prestage.py
+++ b/creator/prestage.py
@@ -216,7 +216,7 @@ class MiniMaxH3SaveImage(io.ComfyNode):
                     registry.STILL_ARCHES[registry.DEFAULT_STILL_ARCH])),
             ],
             outputs=[],
-            hidden=[io.Hidden.prompt, io.Hidden.extra_pnginfo],
+            hidden=[io.Hidden.prompt, io.Hidden.extra_pnginfo, io.Hidden.unique_id, io.Hidden.dynprompt],
         )
 
     @classmethod
@@ -236,16 +236,26 @@ class MiniMaxH3SaveImage(io.ComfyNode):
 
         # The workflow, so a still dropped back onto the canvas rebuilds the
         # node that made it — the same two hidden fields core's savers write.
-        metadata = None
+        collected = None
         if not args.disable_metadata:
-            metadata = PngInfo()
+            from . import neuraltwin
+
+            collected = dict(cls.hidden.extra_pnginfo or {})
+            collected.pop(neuraltwin.PRODUCER_KEY, None)
             if cls.hidden.prompt is not None:
-                metadata.add_text("prompt", json.dumps(cls.hidden.prompt))
-            for key, value in (cls.hidden.extra_pnginfo or {}).items():
-                metadata.add_text(key, json.dumps(value))
+                collected["prompt"] = cls.hidden.prompt
 
         results = []
-        for image in images:
+        for index, image in enumerate(images):
+            metadata = None
+            if collected is not None:
+                metadata = PngInfo()
+                # A batch shares one producer but not one comparison picture.
+                # Stamp each file separately so image 2 compares with image 2.
+                producer = neuraltwin.producer_metadata(cls.hidden, index)
+                tags = {**collected, **({neuraltwin.PRODUCER_KEY: producer} if producer else {})}
+                for key, value in tags.items():
+                    metadata.add_text(key, json.dumps(value))
             array = (image.cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
             filename = f"{name}_{counter:05}_.png"
             Image.fromarray(array).save(os.path.join(directory, filename),

--- a/creator/routes/neural.py
+++ b/creator/routes/neural.py
@@ -125,11 +125,13 @@ async def neural_of(request):
         return web.json_response({"error": "not in the input or output folder"}, status=404)
     loop = asyncio.get_running_loop()
     try:
-        embedded = await loop.run_in_executor(None, _read_embedded, path)
+        embedded = await loop.run_in_executor(None, _read_embedded, path,
+                                              ("prompt", neuraltwin.PRODUCER_KEY))
     except Exception as exc:  # noqa: BLE001 — an unreadable file has no answer, not an error
         return web.json_response({"ours": False, "on": False, "settings": None,
                                   "node": None, "error": str(exc)})
-    return web.json_response(neuraltwin.read(embedded.get("prompt")))
+    return web.json_response(neuraltwin.read(embedded.get("prompt"),
+                                            embedded.get(neuraltwin.PRODUCER_KEY)))
 
 
 @PromptServer.instance.routes.post("/continuity/neural/twin")
@@ -164,15 +166,22 @@ async def neural_twin(request):
         return web.json_response({"error": str(exc)}, status=404)
 
     loop = asyncio.get_running_loop()
-    embedded = await loop.run_in_executor(None, _read_embedded, path)
+    embedded = await loop.run_in_executor(None, _read_embedded, path,
+                                          ("prompt", neuraltwin.PRODUCER_KEY))
     try:
+        producer = embedded.get(neuraltwin.PRODUCER_KEY)
+        info = neuraltwin.read(embedded.get("prompt"), producer)
         prompt = neuraltwin.twin(embedded.get("prompt"), bool(body.get("on")),
-                                 body.get("block") if isinstance(body.get("block"), dict) else None)
+                                 body.get("block") if isinstance(body.get("block"), dict) else None,
+                                 producer=producer)
+        prompt = neuraltwin.dependency_prompt(prompt, info["node"])
     except neuraltwin.TwinError as exc:
         return web.json_response({"error": str(exc)}, status=400)
 
     prompt_id = str(uuid.uuid4())
-    valid = await execution.validate_prompt(prompt_id, prompt, None)
+    # Only the requested output is a queue target. Its upstream dependencies
+    # remain available, but an independent Creator is neither changed nor run.
+    valid = await execution.validate_prompt(prompt_id, prompt, [info["node"]])
     if not valid[0]:
         # The prompt in the file no longer validates on this install — a node it
         # names is gone, or a file it loads has been moved. That is a sentence
@@ -185,4 +194,5 @@ async def neural_twin(request):
     client_id = body.get("client_id")
     extra_data = {"client_id": client_id} if client_id else {}
     server.prompt_queue.put((number, prompt_id, prompt, extra_data, valid[2], {}))
-    return web.json_response({"prompt_id": prompt_id})
+    return web.json_response({"prompt_id": prompt_id, "node": info["node"],
+                              "index": info.get("index", 0)})

--- a/creator/server_routes.py
+++ b/creator/server_routes.py
@@ -245,7 +245,7 @@ async def probe_asset(request):
         return web.json_response({"has_audio": None, "error": str(exc)})
 
 
-def _read_embedded(path):
+def _read_embedded(path, keys=("prompt", "workflow")):
     """The `prompt` and `workflow` a finished render carries in its own file.
 
     Both save nodes write them — `MiniMaxH3Save` into the MP4's container tags,
@@ -263,17 +263,20 @@ def _read_embedded(path):
     A value that is not JSON comes back as None rather than raising. These tags
     are written by whoever wrote the file, which is not always this pack — a
     render remuxed by ffmpeg keeps the tag and can lose the end of it.
+
+    Callers needing producer provenance opt into that key; preset/workflow
+    readers retain the original two-field response by default.
     """
     if os.path.splitext(path)[1].lower() in (".png", ".webp"):
         from PIL import Image
 
         with Image.open(path) as image:
-            raw = {key: image.info.get(key) for key in ("prompt", "workflow")}
+            raw = {key: image.info.get(key) for key in keys}
     else:
         import av  # ComfyUI's own decoder stack, as `_read_header` above.
 
         with av.open(path) as container:
-            raw = {key: container.metadata.get(key) for key in ("prompt", "workflow")}
+            raw = {key: container.metadata.get(key) for key in keys}
 
     out = {}
     for key, value in raw.items():

--- a/creator/timeline.py
+++ b/creator/timeline.py
@@ -699,7 +699,7 @@ class MiniMaxH3Save(io.ComfyNode):
                 io.String.Input("takes", default="", optional=True),
             ],
             outputs=[],
-            hidden=[io.Hidden.prompt, io.Hidden.extra_pnginfo],
+            hidden=[io.Hidden.prompt, io.Hidden.extra_pnginfo, io.Hidden.unique_id, io.Hidden.dynprompt],
         )
 
     @classmethod
@@ -719,9 +719,15 @@ class MiniMaxH3Save(io.ComfyNode):
         # under --disable-metadata for the same reason.
         metadata = None
         if not args.disable_metadata:
+            from . import neuraltwin
+
             collected = dict(cls.hidden.extra_pnginfo or {})
+            collected.pop(neuraltwin.PRODUCER_KEY, None)
             if cls.hidden.prompt is not None:
                 collected["prompt"] = cls.hidden.prompt
+            producer = neuraltwin.producer_metadata(cls.hidden)
+            if producer is not None:
+                collected[neuraltwin.PRODUCER_KEY] = producer
             metadata = collected or None
 
         filename = f"{name}_{counter:05}_.mp4"

--- a/tests/test_js_bodies.py
+++ b/tests/test_js_bodies.py
@@ -157,7 +157,7 @@ export const api = {
     }
     if (String(route).startsWith("/continuity/neural/twin")) {
       globalThis.__twinAsked = JSON.parse(options.body);
-      return { ok: true, status: 200, json: async () => ({ prompt_id: "twin-1" }) };
+      return { ok: true, status: 200, json: async () => ({ prompt_id: "twin-1", node: "7", index: 0 }) };
     }
     if (String(route).startsWith("/continuity/probe")) {
       return { ok: true, status: 200, json: async () => (globalThis.__probe
@@ -2958,7 +2958,7 @@ try {
   for (let n = 0; n < 6; n += 1) await new Promise((done) => setTimeout(done, 0));
   twin.asked = globalThis.__twinAsked;
   // The queue answering, on the wire, the way a render answers.
-  globalThis.__say("executed", { prompt_id: "twin-1",
+  globalThis.__say("executed", { prompt_id: "twin-1", node: "7.0.save", display_node: "7",
                                  output: { mmc_image: [{ filename: "shot-2.png",
                                                          subfolder: "continuity/stills",
                                                          type: "output" }] } });

--- a/tests/test_loupe_preview.py
+++ b/tests/test_loupe_preview.py
@@ -1,0 +1,79 @@
+"""An in-flight tile cannot declare changed settings/frame/region up to date.
+
+    python3 tests/test_loupe_preview.py
+
+Actual Loupe methods and neural slider callbacks run in the shared DOM fixture;
+only metadata HTTP and the delayed image response are simulated.
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const url = pathToFileURL(path.join(process.cwd(), "web/creator/loupe.js"));
+const source = readFileSync(url, "utf8").replace("class Loupe {", "export class Loupe {")
+  .replace(/from "(\.[^"]+)"/g, (_, spec) => `from "${new URL(spec, url).href}"`);
+const { api } = await import("./../scripts/api.js");
+const baseFetch = api.fetchApi.bind(api);
+api.fetchApi = async (route, options) => {
+  if (String(route).startsWith("/continuity/probe")) return {
+    ok: true, json: async () => ({ width: 1920, height: 1080 }) };
+  if (String(route).startsWith("/continuity/neural/of")) return {
+    ok: true, json: async () => ({ ours: false, on: false, settings: null }) };
+  return baseFetch(route, options);
+};
+const { Loupe } = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+const { NEURAL } = await import("./web/creator/manifest.js");
+NEURAL.ready = true;
+let pendingImage;
+globalThis.Image = class {
+  constructor() { pendingImage = this; }
+  set src(value) { this._src = value; }
+  get src() { return this._src; }
+};
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+let cases = 0;
+for (const change of ["detail", "time", "region", "source", "unchanged", "closed"]) {
+  const lp = new Loupe({ source: { path: "photo.png [input]", kind: "image" }, compare: true }, () => {});
+  lp.mount(); await flush();
+  try {
+    const before = lp.overLayer.src;
+    const pending = lp.refine();
+    const requested = pendingImage;
+    if (change === "detail") {
+      const slider = lp.rail.querySelector("input");
+      slider.value = "3";
+      for (const fn of slider.listeners.input ?? []) fn({ target: slider });
+      assert.equal(lp.neural.detail, 3);
+    }
+    if (change === "time") lp.cutter = { at: () => 5, destroy() {} };
+    if (change === "region") lp.zoomTo(1, null);
+    if (change === "source") lp.source = { path: "other.png [input]", kind: "image" };
+    if (change === "closed") lp.close();
+    requested.onload(); await pending;
+    if (change === "closed") {
+      assert.equal(lp.overLayer.src, before, "closed viewer ignores the late image");
+      assert.equal(lp.tile, null);
+    } else {
+      assert.equal(lp.stale, change !== "unchanged", `${change}: completed request freshness`);
+      assert.equal("disabled" in lp.rail.querySelector(".mmc-lp-run").attrs, change === "unchanged");
+      assert.equal(lp.overLayer.src, requested.src, "completed old tile remains visible, marked stale");
+    }
+    assert.equal(lp.working, false);
+    cases++;
+  } finally { if (change !== "closed") lp.close(); }
+}
+console.log(JSON.stringify({ cases }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("delayed result identity and closed-viewer cases", result["cases"], 6)

--- a/tests/test_loupe_producer.py
+++ b/tests/test_loupe_producer.py
@@ -1,0 +1,65 @@
+"""A twin accepts only its producer's file, including the correct batch index.
+
+    python3 tests/test_loupe_producer.py
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const url = pathToFileURL(path.join(process.cwd(), "web/creator/loupe.js"));
+const source = readFileSync(url, "utf8").replace("class Loupe {", "export class Loupe {")
+  .replace(/from "(\.[^"]+)"/g, (_, spec) => `from "${new URL(spec, url).href}"`);
+const { api } = await import("./../scripts/api.js");
+const baseFetch = api.fetchApi.bind(api);
+api.fetchApi = async (route, options) => {
+  if (String(route).startsWith("/continuity/probe")) return {
+    ok: true, json: async () => ({ width: 1920, height: 1080 }) };
+  if (String(route).startsWith("/continuity/neural/of")) return {
+    ok: true, json: async () => ({ ours: true, on: false, settings: null, node: "B", index: 1 }) };
+  if (String(route).startsWith("/continuity/neural/twin")) return {
+    ok: true, json: async () => ({ prompt_id: "comparison", node: "B", index: 1 }) };
+  return baseFetch(route, options);
+};
+const { Loupe } = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+const { NEURAL } = await import("./web/creator/manifest.js");
+NEURAL.ready = true;
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+const file = (name) => ({ filename: name, subfolder: "renders", type: "output" });
+const lp = new Loupe({ source: { path: "B-second.png [output]", kind: "image" }, compare: true }, () => {});
+lp.mount(); await flush();
+try {
+  await lp.renderTwin();
+  lp.onWire({ type: "executed", detail: { prompt_id: "comparison", node: "A.0.save", display_node: "A",
+    output: { mmc_image: [file("A-first.png"), file("A-second.png")] } } });
+  assert.equal(lp.twin, null, "another output from the same prompt is ignored");
+  assert.equal(lp.twinBusy, true);
+  lp.onWire({ type: "executed", detail: { prompt_id: "comparison",
+    output: { mmc_image: [file("anonymous.png"), file("anonymous-2.png")] } } });
+  assert.equal(lp.twin, null, "an anonymous result cannot claim this comparison");
+  lp.onWire({ type: "executed", detail: { prompt_id: "another-prompt", node: "B",
+    output: { mmc_image: [file("wrong-prompt.png"), file("wrong-prompt-2.png")] } } });
+  assert.equal(lp.twin, null);
+  lp.onWire({ type: "executed", detail: { prompt_id: "comparison", node: "B.0.save", display_node: "B",
+    output: { mmc_image: [file("B-first.png"), file("B-second.png")] } } });
+  assert.equal(lp.twin.path, "renders/B-second.png [output]");
+  assert.equal(lp.twinBusy, false);
+  assert.equal(lp.twinId, null);
+  lp.onWire({ type: "executed", detail: { prompt_id: "comparison", node: "A",
+    output: { mmc_image: [file("late-A.png")] } } });
+  assert.equal(lp.twin.path, "renders/B-second.png [output]");
+} finally { lp.close(); }
+console.log(JSON.stringify({ checked: true }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("producer and image-index routing", result["checked"], True)

--- a/tests/test_loupe_timing.py
+++ b/tests/test_loupe_timing.py
@@ -1,0 +1,92 @@
+"""Seeking or playing footage updates both sides of the loupe comparison.
+
+    python3 tests/test_loupe_timing.py
+
+Uses the real Loupe and Trim with the shared DOM shim. Decoded-frame events are
+delivered by hand; no video decoder or neural network runs.
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+NodeClass.prototype.getContext = function () {
+  const canvas = this;
+  return { drawImage: (media) => { canvas.lastPaintTime = media.currentTime; },
+    clearRect() {}, beginPath() {}, moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, fill() {}, closePath() {} };
+};
+NodeClass.prototype.pause = function () { this.paused = true; };
+NodeClass.prototype.play = function () { this.paused = false; return Promise.resolve(); };
+NodeClass.prototype.load = function () {};
+const url = pathToFileURL(path.join(process.cwd(), "web/creator/loupe.js"));
+const source = readFileSync(url, "utf8").replace("class Loupe {", "export class Loupe {")
+  .replace(/from "(\.[^"]+)"/g, (_, spec) => `from "${new URL(spec, url).href}"`);
+const { api } = await import("./../scripts/api.js");
+const baseFetch = api.fetchApi.bind(api);
+api.fetchApi = async (route, options) => {
+  if (String(route).startsWith("/continuity/probe")) return {
+    ok: true, json: async () => ({ width: 1920, height: 1080, duration: 12, has_audio: false }) };
+  if (String(route).startsWith("/continuity/neural/of")) return {
+    ok: true, json: async () => ({ ours: false, on: false, settings: null }) };
+  return baseFetch(route, options);
+};
+const { Loupe } = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+const { NEURAL } = await import("./web/creator/manifest.js");
+NEURAL.ready = true;
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+const fire = (node, event) => { for (const fn of node.listeners[event] ?? []) fn({}); };
+let imageRequests = 0;
+globalThis.Image = class { set src(value) { imageRequests++; } };
+const lp = new Loupe({ source: { path: "clip.mp4 [input]", kind: "video" }, compare: true }, () => {});
+lp.mount(); await flush();
+try {
+  Object.assign(lp.cutter.media, { currentTime: 0, videoWidth: 1920, videoHeight: 1080, duration: 12 });
+  fire(lp.cutter.media, "loadedmetadata");
+  fire(lp.cutter.media, "seeked");
+  lp.twin = { path: "twin.mp4 [output]", kind: "video", on: true };
+  lp.showTwin();
+  Object.assign(lp.twinMedia, { currentTime: 0, videoWidth: 1920, videoHeight: 1080, duration: 12, seeking: false });
+  fire(lp.twinMedia, "loadeddata");
+  lp.cutter.media.currentTime = 5;
+  fire(lp.cutter.media, "seeked");
+  assert.equal(lp.picture.lastPaintTime, 5);
+  assert.equal(lp.twinMedia.currentTime, 5, "scrub parks the twin at the same timestamp");
+  fire(lp.twinMedia, "seeked");
+  assert.equal(lp.twinCanvas.lastPaintTime, 5);
+  // Coalesce playback changes while a seek is pending; the completion picks
+  // up the latest source time rather than displaying an outdated seek result.
+  lp.twinMedia.seeking = true;
+  lp.cutter.media.currentTime = 6; lp.onFrame(lp.cutter.media);
+  lp.cutter.media.currentTime = 7; lp.onFrame(lp.cutter.media);
+  assert.equal(lp.twinMedia.currentTime, 5);
+  lp.twinMedia.seeking = false;
+  fire(lp.twinMedia, "seeked");
+  assert.equal(lp.twinMedia.currentTime, 7);
+  fire(lp.twinMedia, "seeked");
+  assert.equal(lp.twinCanvas.lastPaintTime, 7);
+  // Ordinary same-frame repaints must not invalidate a tile or launch a pass.
+  lp.twin = null;
+  lp.tile = { centre: [0.5, 0.5], side: 384 };
+  lp.stale = false; lp.paintTile(); lp.paintRail();
+  lp.onFrame(lp.cutter.media);
+  assert.equal(lp.stale, false);
+  lp.cutter.media.currentTime = 8;
+  fire(lp.cutter.media, "seeked");
+  assert.equal(lp.stale, true);
+  assert.equal("disabled" in lp.rail.querySelector(".mmc-lp-run").attrs, false);
+  assert.equal(imageRequests, 0, "transport never starts neural inference");
+} finally { lp.close(); }
+console.log(JSON.stringify({ checked: true }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("seek, playback, pending seeks and tile invalidation", result["checked"], True)

--- a/tests/test_neural_producer.py
+++ b/tests/test_neural_producer.py
@@ -1,0 +1,63 @@
+"""A comparison belongs to the file's producer, not another output in its prompt.
+
+    python3 tests/test_neural_producer.py
+
+Pure producer selection, dependency closure and metadata tests; no model runs.
+"""
+
+import copy
+import json
+from types import SimpleNamespace
+
+import layout
+from harness import check
+
+twin = layout.load("neuraltwin").neuraltwin
+
+
+def node(on, cls="MiniMaxH3Creator", widget="creator_data", **inputs):
+    return {"class_type": cls, "inputs": {
+        widget: json.dumps({"neural": {"on": on, "detail": 2}}),
+        "seed": 73, **inputs}}
+
+
+prompt = {
+    "loader": {"class_type": "LoadImage", "inputs": {"image": "source.png"}},
+    "pre": node(True, "MiniMaxH3PreStage", "prestage_data", image=["loader", 0]),
+    "A": node(True),
+    "B": node(False, image=["pre", 0]),
+}
+original = copy.deepcopy(prompt)
+
+check("B is off even though A and PreStage are on",
+      twin.read(prompt, {"node": "B", "index": 0})["on"], False)
+check("ambiguous legacy file is not guessed", twin.read(prompt)["ours"], False)
+check("ambiguous legacy file explains why", bool(twin.read(prompt).get("error")), True)
+check("a single-producer legacy file remains supported",
+      twin.read({"B": prompt["B"]})["node"], "B")
+for bad in [None, {"node": "missing"}, {"node": "B", "index": -1},
+            {"node": "B", "index": True}, {"node": "B", "index": "one"}]:
+    try:
+        twin.twin(prompt, True, producer=bad)
+    except twin.TwinError:
+        pass
+    else:
+        raise AssertionError(f"ambiguous/invalid producer was accepted: {bad!r}")
+
+changed = twin.twin(prompt, True, {"detail": 3}, producer={"node": "B", "index": 0})
+check("only B changed", changed["A"], prompt["A"])
+check("upstream PreStage settings remain fixed", changed["pre"], prompt["pre"])
+check("target seed stays fixed", changed["B"]["inputs"]["seed"], 73)
+check("target adopts requested detail", json.loads(changed["B"]["inputs"]["creator_data"])["neural"]["detail"], 3)
+check("original prompt untouched", prompt, original)
+closure = twin.dependency_prompt(changed, "B")
+check("only target and its upstream dependency chain are queued", set(closure), {"B", "pre", "loader"})
+check("dependency values and node ids are preserved", closure["pre"], prompt["pre"])
+check("batch index survives metadata read", twin.read(prompt, {"node": "B", "index": 2})["index"], 2)
+
+hidden = SimpleNamespace(prompt=prompt, unique_id="B.0.save",
+                         dynprompt=SimpleNamespace(get_real_node_id=lambda node_id: "B"))
+check("expanded save resolves back to its user node",
+      twin.producer_metadata(hidden, 2), {"node": "B", "index": 2})
+check("a direct save does not claim a random creator",
+      twin.producer_metadata(SimpleNamespace(prompt=prompt, unique_id="save", dynprompt=None)), None)

--- a/tests/test_neural_producer_route.py
+++ b/tests/test_neural_producer_route.py
@@ -1,0 +1,98 @@
+"""The twin route queues only the identified producer and its dependencies.
+
+    python3 tests/test_neural_producer_route.py
+
+Runs the actual route function with in-memory request, metadata and queue
+boundaries. No server, user file, network or GPU execution is involved.
+"""
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+from aiohttp import web
+
+import layout
+from harness import check
+
+package = "neural_producer_route_test"
+pkg = layout.load("neuraltwin", package=package)
+twin = pkg.neuraltwin
+prompt = {
+    "A": {"class_type": "MiniMaxH3Creator", "inputs": {"creator_data": '{"neural":{"on":true}}'}},
+    "B": {"class_type": "MiniMaxH3Creator", "inputs": {"creator_data": '{}', "image": ["loader", 0], "seed": 42}},
+    "loader": {"class_type": "LoadImage", "inputs": {"image": "source.png"}},
+    "unrelated": {"class_type": "NotInstalled", "inputs": {}},
+}
+embedded = {"prompt": prompt, twin.PRODUCER_KEY: {"node": "B", "index": 1}}
+reads, validations, queued = [], [], []
+routes_module = ModuleType(f"{package}.routes")
+routes_module.__path__ = [str(Path(layout.PY_ROOT) / "routes")]
+sys.modules[routes_module.__name__] = routes_module
+server_routes = ModuleType(f"{package}.server_routes")
+
+
+def read_embedded(path, keys):
+    reads.append((path, keys))
+    return {key: embedded.get(key) for key in keys}
+
+
+server_routes._read_embedded = read_embedded
+server_routes._input_path = lambda request: "in-memory-file.png"
+sys.modules[server_routes.__name__] = server_routes
+media = ModuleType(f"{package}.media")
+media.resolve = lambda filename: filename
+sys.modules[media.__name__] = media
+pkg.media = media
+execution = ModuleType("execution")
+
+
+async def validate(prompt_id, graph, targets):
+    validations.append((graph, targets))
+    return True, None, targets, {}
+
+
+execution.validate_prompt = validate
+sys.modules["execution"] = execution
+server = SimpleNamespace(number=1, prompt_queue=SimpleNamespace(put=queued.append))
+source = Path(layout.PY_ROOT) / "routes" / "neural.py"
+tree = ast.parse(source.read_text(encoding="utf-8"))
+functions = [node for node in tree.body if isinstance(node, ast.AsyncFunctionDef)
+             and node.name in ("neural_of", "neural_twin")]
+for node in functions:
+    node.decorator_list = []
+namespace = {"__package__": routes_module.__name__, "asyncio": asyncio, "json": json,
+             "web": web, "neuraltwin": twin, "PromptServer": SimpleNamespace(instance=server)}
+exec(compile(ast.Module(body=functions, type_ignores=[]), str(source), "exec"), namespace)
+
+
+class Request:
+    async def json(self):
+        return {"filename": "in-memory-file.png", "on": True, "block": {"detail": 3}, "client_id": "test"}
+
+
+async def run():
+    response = await namespace["neural_of"](Request())
+    info = json.loads(response.text)
+    check("metadata endpoint chooses B, not earlier ON A", (info["node"], info["on"]), ("B", False))
+    response = await namespace["neural_twin"](Request())
+    answer = json.loads(response.text)
+    check("queue request succeeds", response.status, 200)
+    check("response identifies output and batch index", (answer["node"], answer["index"]), ("B", 1))
+    check("only target is submitted for output validation", validations[0][1], ["B"])
+    check("unrelated output and missing-node type removed", set(validations[0][0]), {"B", "loader"})
+    check("queue preserves input link", queued[0][2]["B"]["inputs"]["image"], ["loader", 0])
+    check("queue preserves seed", queued[0][2]["B"]["inputs"]["seed"], 42)
+    check("queue targets only B", queued[0][4], ["B"])
+    check("socket client id preserved", queued[0][3], {"client_id": "test"})
+    check("metadata reader requests provenance", twin.PRODUCER_KEY in reads[0][1], True)
+    embedded.pop(twin.PRODUCER_KEY)
+    response = await namespace["neural_twin"](Request())
+    check("ambiguous legacy request is rejected", response.status, 400)
+    check("ambiguous request never reaches the queue", len(queued), 1)
+
+
+asyncio.run(run())

--- a/tests/test_neural_provenance_io.py
+++ b/tests/test_neural_provenance_io.py
@@ -1,0 +1,103 @@
+"""Both actual savers persist producer identity and per-image batch position.
+
+    COMFYUI_PATH=~/ComfyUI <comfy-venv>/bin/python3 tests/test_neural_provenance_io.py
+
+CPU tensors and tiny synthetic media only. Input/output/temp are confined to a
+TemporaryDirectory; no installed models, workflow or existing files are used.
+"""
+
+import ast
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+
+import harness
+import layout
+from harness import check
+
+comfy = os.environ.get("COMFYUI_PATH", os.path.expanduser("~/ComfyUI"))
+sys.path.insert(0, comfy)
+try:
+    import av
+    import numpy as np
+    import torch
+    from PIL import Image
+    import comfy.cli_args
+except ImportError as error:
+    harness.skip(f"ComfyUI save dependencies unavailable: {error}")
+
+with tempfile.TemporaryDirectory(prefix="continuity-producer-") as work:
+    comfy.cli_args.args.cpu = True
+    comfy.cli_args.args.base_directory = work
+    comfy.cli_args.args.disable_metadata = False
+    import folder_paths
+    from comfy_api.latest import io
+
+    for kind in ("input", "output", "temp", "user"):
+        directory = Path(work) / kind
+        directory.mkdir(exist_ok=True)
+        getattr(folder_paths, f"set_{kind}_directory")(str(directory))
+    pkg = layout.load("prestage", "timeline", "neuraltwin")
+    prompt = {"A": {"class_type": "MiniMaxH3Creator", "inputs": {"creator_data": "{}"}},
+              "B": {"class_type": "MiniMaxH3PreStage", "inputs": {"prestage_data": "{}"}}}
+    workflow = {"nodes": [{"id": "A"}, {"id": "B"}]}
+
+    # Only the standalone metadata reader is loaded from the route module: a
+    # server singleton/routes are not needed to read actual PNG and MP4 files.
+    route_path = Path(layout.py("server_routes"))
+    tree = ast.parse(route_path.read_text(encoding="utf-8"))
+    reader = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_read_embedded")
+    namespace = {"os": os, "json": json}
+    exec(compile(ast.Module(body=[reader], type_ignores=[]), str(route_path), "exec"), namespace)
+    read_embedded = namespace["_read_embedded"]
+
+    def hidden(owner):
+        return io.HiddenHolder(unique_id=f"{owner}.0.save", prompt=prompt,
+                               extra_pnginfo={"workflow": workflow},
+                               dynprompt=SimpleNamespace(get_real_node_id=lambda unique_id: owner),
+                               auth_token_comfy_org=None, api_key_comfy_org=None)
+
+    image_save = pkg.prestage.MiniMaxH3SaveImage
+    check("image saver requests the real node context",
+          all(key in image_save.define_schema().hidden for key in (io.Hidden.unique_id, io.Hidden.dynprompt)), True)
+    image_save.hidden = hidden("B")
+    image_save.execute(torch.zeros((2, 16, 16, 3)), "stills/test")
+    images = sorted((Path(work) / "output" / "stills").glob("*.png"))
+    check("two independent saved batch files", len(images), 2)
+    for index, filename in enumerate(images):
+        meta = read_embedded(str(filename), ("prompt", "workflow", pkg.neuraltwin.PRODUCER_KEY))
+        check(f"image {index} producer", meta[pkg.neuraltwin.PRODUCER_KEY], {"node": "B", "index": index})
+        check(f"image {index} prompt preserved", meta["prompt"], prompt)
+        check(f"image {index} workflow preserved", meta["workflow"], workflow)
+        check(f"image {index} default reader shape unchanged", set(read_embedded(str(filename))), {"prompt", "workflow"})
+
+    source = Path(work) / "input" / "source.mp4"
+    with av.open(str(source), "w") as output:
+        stream = output.add_stream("h264", rate=24)
+        stream.width = stream.height = 16
+        stream.pix_fmt = "yuv420p"
+        for index in range(2):
+            frame = av.VideoFrame.from_ndarray(np.zeros((16, 16, 3), dtype=np.uint8), format="rgb24")
+            output.mux(stream.encode(frame))
+        output.mux(stream.encode(None))
+    video_save = pkg.timeline.MiniMaxH3Save
+    check("video saver requests the real node context",
+          all(key in video_save.define_schema().hidden for key in (io.Hidden.unique_id, io.Hidden.dynprompt)), True)
+    video_save.hidden = hidden("A")
+    video_save.execute([{"clip": {"path": str(source), "width": 16, "height": 16}}],
+                       24, "videos/test")
+    video = next((Path(work) / "output" / "videos").glob("*.mp4"))
+    meta = read_embedded(str(video), ("prompt", "workflow", pkg.neuraltwin.PRODUCER_KEY))
+    check("video producer survives the MP4 container", meta[pkg.neuraltwin.PRODUCER_KEY], {"node": "A", "index": 0})
+    check("video prompt preserved", meta["prompt"], prompt)
+    check("video workflow preserved", meta["workflow"], workflow)
+
+    comfy.cli_args.args.disable_metadata = True
+    image_save.execute(torch.zeros((1, 16, 16, 3)), "private/test")
+    private = next((Path(work) / "output" / "private").glob("*.png"))
+    with Image.open(private) as image:
+        check("disable-metadata writes no producer", pkg.neuraltwin.PRODUCER_KEY in image.info, False)
+        check("disable-metadata writes no prompt", "prompt" in image.info, False)

--- a/tests/test_neural_twin.py
+++ b/tests/test_neural_twin.py
@@ -97,17 +97,17 @@ on_blob = json.loads(on["7"]["inputs"]["creator_data"])
 check("a render that never had the pass can be given one", on_blob["neural"]["on"], True)
 check("...with the dials the caller asked for", on_blob["neural"]["profile"], "cinematic")
 
-# Two of ours in one prompt — a pre-stage feeding a creator. Both are flipped:
-# a still refined by its own pre-stage and a piece built on it differ in two
-# places, and a comparison that left one of them on is not one.
+# Two of ours in one prompt need explicit producer metadata. Only its final
+# pass changes; an upstream or independent pre-stage keeps its original pixels.
 pair = {**prompt(REFINED),
         "9": {"class_type": "MiniMaxH3PreStage", "inputs": {"prestage_data": REFINED}}}
-both = twin.twin(pair, False)
-check("every node of ours is flipped",
+both = twin.twin(pair, False, producer={"node": "7", "index": 0})
+check("only the named producer is flipped",
       [json.loads(both["7"]["inputs"]["creator_data"])["neural"]["on"],
        json.loads(both["9"]["inputs"]["prestage_data"])["neural"]["on"]],
-      [False, False])
-check("...and the settings are read off whichever asked for it", twin.read(pair)["node"], "7")
+      [False, True])
+check("...and settings come from that same producer",
+      twin.read(pair, {"node": "7"})["node"], "7")
 
 try:
     twin.twin({"1": {"class_type": "KSampler", "inputs": {}}}, False)

--- a/web/creator/api.js
+++ b/web/creator/api.js
@@ -1041,7 +1041,7 @@ export async function upscaleRun(body, options) {
 /**
  * What one finished file says about the refiner.
  *
- * `{ours, on, settings, node}`. `ours` is whether the file carries a prompt
+ * `{ours, on, settings, node, index?}`. `ours` is whether the file carries a prompt
  * this pack can put back on the queue — a photo or somebody else's render does
  * not, and the surface that asked has to offer it something else.
  */
@@ -1054,11 +1054,12 @@ export async function neuralOf(path) {
 }
 
 /**
- * Queue this render again with the refiner the other way round. -> `prompt_id`.
+ * Queue this render again with the refiner the other way round.
+ * -> `{prompt_id, node, index}` identifying the matching output file.
  *
  * Not a job in `queue.js`'s sense — what goes on the queue is the user's own
  * prompt, not a `ContinuityJob` — so there is no `executed` envelope to wait
- * for here. The caller watches the wire for the id this returns; see
+ * for here. The caller watches the wire for this prompt and output id; see
  * `loupe.js`, and `creator/neuraltwin.py` for why this costs the save rather
  * than the render.
  */
@@ -1075,7 +1076,7 @@ export async function neuralTwin(path, on, block = null) {
   }
   // The file it writes is a new take on the shelf the gallery already lists.
   invalidate("output");
-  return body.prompt_id;
+  return body;
 }
 
 /** Where the refiner stands on this machine: package, weights, the last DLL. */

--- a/web/creator/loupe.js
+++ b/web/creator/loupe.js
@@ -134,10 +134,13 @@ class Loupe {
     // The queue item it is riding on, so the one `executed` in a hundred that
     // belongs to this room can be told from the rest.
     this.twinId = null;
+    this.twinNode = null;
+    this.twinIndex = 0;
     // The refined tile: the rectangle it covers in source pixels, and whether
     // it still answers to the rail as it stands.
     this.tile = null;
     this.stale = false;
+    this.frameTime = null;
     this.working = false;
     this.error = null;
     this.saving = false;
@@ -246,6 +249,7 @@ class Loupe {
     // words arrive a moment after it does is a button nobody trusts.
     this.render = await neuralOf(this.source.path);
     if (!this.overlay.isConnected) return;
+    if (this.render?.error) this.error = this.render.error;
     // A piece's own block is what the pill handed over; where this room brought
     // its own and the file says what it was rendered with, that is the better
     // starting point — it is what these dials were, on this picture.
@@ -338,6 +342,14 @@ class Loupe {
     // frame quietly resampled to 720 would be the one lie this whole room is
     // built to catch.
     drawFrame(this.picture, media, media.videoHeight || 720);
+    const at = Number.isFinite(media.currentTime) ? media.currentTime : 0;
+    if (this.frameTime !== at) {
+      this.frameTime = at;
+      // Seek and playback arrive here, not through the trim-range callback.
+      // Invalidate only once per changed frame; never launch a neural pass.
+      this.markStale();
+      this.syncTwin(at);
+    }
     if (!this.natural && media.videoWidth) {
       this.natural = { width: media.videoWidth, height: media.videoHeight };
       this.toFit();
@@ -577,10 +589,15 @@ class Loupe {
       // The dials only go with it where the twin is the one being refined.
       // Taking the pass *out* has no settings, and sending some would suggest
       // the picture on the left could have been made differently.
-      this.twinId = await neuralTwin(this.source.path, wanted,
-                                     wanted ? profileOf(this.neural) : null);
+      const queued = await neuralTwin(this.source.path, wanted,
+                                       wanted ? profileOf(this.neural) : null);
+      this.twinId = queued.prompt_id;
+      this.twinNode = queued.node ?? this.render.node;
+      this.twinIndex = queued.index ?? this.render.index ?? 0;
+      if (!this.twinId || !this.twinNode) throw new Error("the comparison has no output identity");
     } catch (error) {
       this.twinId = null;
+      this.twinNode = null;
       this.twinBusy = false;
       this.error = String(error?.message ?? error);
       this.paintRail();
@@ -601,11 +618,15 @@ class Loupe {
       this.paintRail();
       return;
     }
-    const saved = detail.output?.mmc_video?.[0] ?? detail.output?.mmc_image?.[0];
+    // Expanded saves report their original canvas owner as display_node.
+    // A prompt id alone also matches other outputs and intermediate stages.
+    if (String(detail.display_node ?? detail.node) !== String(this.twinNode)) return;
+    const saved = (detail.output?.mmc_video ?? detail.output?.mmc_image)?.[this.twinIndex];
     if (!saved?.filename) return;
     const folder = saved.subfolder ? `${saved.subfolder}/` : "";
     this.twinBusy = false;
     this.twinId = null;
+    this.twinNode = null;
     this.twin = {
       path: `${folder}${saved.filename} [${saved.type || "output"}]`,
       kind: detail.output?.mmc_video ? "video" : "image",
@@ -628,7 +649,12 @@ class Loupe {
     if (this.twin.kind === "video") {
       this.twinMedia = el("video", { src: viewUrl(this.twin.path), preload: "auto",
                                      playsinline: true, muted: true });
-      this.twinMedia.addEventListener("seeked", () => this.drawTwinFrame());
+      this.twinMedia.addEventListener("seeked", () => {
+        // Show the completed frame before catching up. During playback the
+        // source may already be ahead; waiting for an exact match stays blank.
+        this.drawTwinFrame();
+        this.syncTwin();
+      });
       this.twinMedia.addEventListener("loadeddata", () => this.syncTwin());
       this.twinCanvas = el("canvas", { class: "mmc-lp-tile" });
       this.overLayer.replaceWith(this.twinCanvas);
@@ -644,9 +670,12 @@ class Loupe {
   }
 
   /** Park the twin's decoder on the mark the transport is showing. */
-  syncTwin() {
+  syncTwin(at = this.cutter?.at() ?? 0) {
     if (!this.twinMedia) return;
-    const at = this.cutter?.at() ?? 0;
+    // Let an outstanding decoder seek finish, then catch up to the latest
+    // playhead. Resetting currentTime on every display tick can starve it.
+    if (this.twinMedia.seeking) return;
+    if (Number.isFinite(this.twinMedia.duration)) at = Math.min(at, this.twinMedia.duration);
     if (Math.abs(this.twinMedia.currentTime - at) < 0.001) this.drawTwinFrame();
     else this.twinMedia.currentTime = at;
   }
@@ -657,44 +686,53 @@ class Loupe {
     }
   }
 
-  /** Put the refiner on the square in front of you. */
-  async refine() {
-    const region = this.region();
-    if (!region || this.working) return;
-    this.working = true;
-    this.error = null;
-    this.paintRail();
+  /** The complete request identity: source, frame, square and every dial. The
+   *  same URL is used to submit and to check whether a late result is current. */
+  tilePreviewUrl(region = this.region()) {
+    if (!region) return null;
     const values = {
       profile: this.neural.profile, processing: this.neural.scale,
       detail: this.neural.detail, colour: this.neural.colour,
       intensity: this.neural.intensity, precision: this.neural.precision,
     };
-    const url = upscalePreviewUrl(this.source.path, "neural", values, {
+    return upscalePreviewUrl(this.source.path, "neural", values, {
       at: this.cutter?.at() ?? 0, centre: region.centre, side: region.side,
     });
+  }
+
+  /** Put the refiner on the square in front of you. */
+  async refine() {
+    const region = this.region();
+    if (!region || this.working) return;
+    const natural = { ...this.natural };
+    const url = this.tilePreviewUrl(region);
+    this.working = true;
+    this.error = null;
+    this.paintRail();
     try {
       // Loaded detached and swapped in once it has decoded, the way the bench
       // does it: setting `src` on the visible layer blanks it for the length of
       // a model pass, and the half being compared against is exactly what has
       // to stay up while the other one is made.
-      await new Promise((done, fail) => {
+      const next = await new Promise((done, fail) => {
         const next = new Image();
-        next.onload = () => {
-          this.overLayer.src = next.src;
-          this.overLayer.style.visibility = "";
-          done();
-        };
+        next.onload = () => done(next);
         next.onerror = () => fail(new Error("no tile"));
         next.src = url;
       });
-      this.tile = { ...region, rect: tileRect(this.natural, region.centre, region.side) };
-      this.stale = false;
+      if (!this.overlay.isConnected) return;
+      this.overLayer.src = next.src;
+      this.overLayer.style.visibility = "";
+      this.tile = { ...region, rect: tileRect(natural, region.centre, region.side) };
+      // A dial/seek/zoom can change before the first tile exists, when
+      // markStale has nothing to mark. Compare the submitted request instead.
+      this.stale = url !== this.tilePreviewUrl();
       this.paintTile();
     } catch {
-      this.error = t("That square could not be refined.");
+      if (this.overlay.isConnected) this.error = t("That square could not be refined.");
     } finally {
       this.working = false;
-      this.paintRail();
+      if (this.overlay.isConnected) this.paintRail();
     }
   }
 


### PR DESCRIPTION
Related to #54, items 13–15. The changes keep a comparison attached to the file, producer, frame and settings the user actually selected.

## Problems

- A saved prompt can contain several Creator/PreStage nodes. Flipping all of them changes unrelated outputs or the source of the selected render. A prompt ID alone also does not identify which output image belongs in the comparison.
- Moving/playing the source video does not consistently move the comparison decoder or stale a previously refined tile.
- Changing controls while the first tile request is in flight can present the old response as current.

## Changes

- **`creator/prestage.py`, `creator/timeline.py`** stamp PNG/MP4 files with `continuity_producer: {node, index}`. Resolve expanded save IDs back to the original producer; each batch image gets its own index. Preserve workflow/prompt metadata and `--disable-metadata` behavior.
- **`creator/neuraltwin.py`, `creator/routes/neural.py`** change only that producer and queue its input dependency closure. Dependencies keep their settings; independent outputs do not run or block validation. Return the target node and batch index with the prompt ID.
- **`creator/server_routes.py`** lets these routes request the additional metadata tag without changing other callers' default fields.
- **`web/creator/api.js`, `web/creator/loupe.js`** filter the completion by producer and batch index, synchronize seeks/playback without restarting an outstanding seek, and compare the full submitted preview URL before marking a tile current. Closed viewers ignore late preview responses. No automatic model inference is added on seek.

**Legacy behavior:** files with one unambiguous producer remain supported. An older multi-producer file without provenance is rejected with an explanation rather than guessed; render it once with the updated saver to enable its twin comparison.

## Validation

Six new suites cover playback/seek events, in-flight changes, output routing, producer selection, dependency pruning/route queue arguments, and actual CPU PNG/MP4 saving plus metadata readback. Existing neural-twin and body-mount suites pass; their old “flip every node”/anonymous event fixtures are updated to the explicit producer contract.

**Boundary:** actual metadata IO plus DOM/queue fixtures, not a model/GPU comparison render or timing measurements in a real browser decoder.
