### PR TITLE
Correct profile resets and stored preference counts

### DIFF
--- a/tests/test_neural_profile_reset.py
+++ b/tests/test_neural_profile_reset.py
@@ -1,0 +1,44 @@
+"""Every neural dial resets to the active profile, not the standard profile.
+
+    python3 tests/test_neural_profile_reset.py
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const S = await import("./web/creator/state.js");
+const { neuralRail } = await import("./web/creator/neural.js");
+let cases = 0;
+for (const profile of S.NEURAL_PROFILES) {
+  const block = S.parseNeural({ on: true, profile, detail: 2, colour: 2, intensity: 0.5, scale: 2 });
+  const root = document.createElement("div");
+  root.replaceChildren(...neuralRail({ block, ranges: S.NEURAL_RANGES, still: true, onChange() {} }));
+  const defaults = S.neuralDefaultsFor(profile);
+  for (const [index, key] of ["detail", "colour", "intensity", "scale"].entries()) {
+    const slider = root.querySelectorAll("input")[index];
+    for (const fn of slider.listeners.dblclick ?? []) fn({ target: slider, preventDefault() {} });
+    assert.equal(block[key], defaults[key], `${profile}: ${key} reset`);
+    assert.equal(slider.value, String(defaults[key]));
+    cases++;
+  }
+}
+// A rail can stay mounted while its owner adopts a different profile.
+const block = S.parseNeural({ on: true, profile: "standard", detail: 3 });
+const root = document.createElement("div");
+root.replaceChildren(...neuralRail({ block, ranges: S.NEURAL_RANGES, onChange() {} }));
+block.profile = "natural";
+const slider = root.querySelector("input");
+for (const fn of slider.listeners.dblclick ?? []) fn({ target: slider, preventDefault() {} });
+assert.equal(block.detail, S.neuralDefaultsFor("natural").detail);
+console.log(JSON.stringify({ cases }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("four dials for every neural profile", result["cases"], 16)

--- a/tests/test_picker_inventory.py
+++ b/tests/test_picker_inventory.py
@@ -1,0 +1,62 @@
+"""Stored data counts every preference its picker/layout row can remove.
+
+    python3 tests/test_picker_inventory.py
+
+Only the existing in-memory userdata and DOM fixtures are used. No actual
+browser settings, workflow, media, or server files are read or removed.
+"""
+
+import layout
+from domshim import DOM
+from harness import check
+
+layout.skip_without_node()
+
+SCRIPT = r'''
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+globalThis.app = { extensionManager: { setting: { get: () => "en" } } };
+const prefs = await import("./web/creator/api.js");
+const settingsURL = pathToFileURL(path.join(process.cwd(), "web/creator/settings.js"));
+// Export the private page/row for this test; all method bodies stay intact.
+const source = readFileSync(settingsURL, "utf8")
+  .replace("class SettingsPage {", "export class SettingsPage {")
+  .replace("const STORED = [", "export const STORED = [")
+  .replace(/from "(\.[^"]+)"/g, (_, spec) => `from "${new URL(spec, settingsURL).href}"`);
+const { SettingsPage, STORED } = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+const row = STORED.find((entry) => entry.id === "picker");
+const page = new SettingsPage(() => {});
+let cases = 0;
+for (const fixture of [
+  { favorites: [], input: "references", renders: "all", plate: null, view: null, count: 1 },
+  { favorites: [], input: "all", renders: "renders", plate: null, view: null, count: 1 },
+  { favorites: [], input: "all", renders: "all", plate: "0.5", view: null, count: 1 },
+  { favorites: [], input: "all", renders: "all", plate: null, view: "simple", count: 1 },
+  { favorites: ["a.png [input]"], input: "references", renders: "renders", plate: "1", view: "full", count: 5 },
+  { favorites: [], input: "all", renders: "all", plate: null, view: null, count: 0 },
+]) {
+  await row.remove();
+  prefs.savePickerPrefs({ favorites: fixture.favorites,
+    lastShelf: { input: fixture.input, renders: fixture.renders } });
+  if (fixture.plate !== null) localStorage.setItem("mmc.fullscreen.plate", fixture.plate);
+  if (fixture.view !== null) localStorage.setItem("mmc.fullscreen.view", fixture.view);
+  localStorage.setItem("unrelated-preference", "preserve me");
+  await page.takeStock();
+  assert.equal(page.kept.picker, fixture.count);
+  const node = page.storedRow(row);
+  assert.equal("disabled" in node.querySelector("button").attrs, fixture.count === 0);
+  assert.equal(STORED.filter((entry) => entry.held(page.kept) !== 0).includes(row), fixture.count > 0);
+  await row.remove();
+  await page.takeStock();
+  assert.equal(page.kept.picker, 0);
+  assert.equal(localStorage.getItem("unrelated-preference"), "preserve me");
+  cases++;
+}
+console.log(JSON.stringify({ cases }));
+'''
+
+with layout.pack(skip=["atlas"]) as target:
+    result = layout.in_pack(DOM + SCRIPT, target)
+check("preferences can be counted and cleared independently", result["cases"], 6)

--- a/web/creator/api.js
+++ b/web/creator/api.js
@@ -201,7 +201,10 @@ export async function clearPickerPrefs() {
  *  say what it is about to remove. */
 export async function pickerPrefsHeld() {
   const prefs = await loadPickerPrefs();
-  return prefs.favorites.length;
+  // Remembered folders are records too: an empty star list must not disable
+  // the only control that clears where the picker was left.
+  return prefs.favorites.length
+    + Object.values(prefs.lastShelf).filter((shelf) => shelf !== "all").length;
 }
 
 // ---- settings ---------------------------------------------------------------

--- a/web/creator/fullscreen.js
+++ b/web/creator/fullscreen.js
@@ -129,6 +129,16 @@ export function forgetLayout() {
   }
 }
 
+/** Inventory the same keys that forgetLayout removes. Count a stored default
+ *  too: it is still a remembered choice, not an absent preference. */
+export function layoutPrefsHeld() {
+  let count = 0;
+  for (const key of [VIEW_KEY, PLATE_KEY]) {
+    try { if (localStorage.getItem(key) !== null) count++; } catch { /* inaccessible */ }
+  }
+  return count;
+}
+
 function storedPlate() {
   try {
     const seen = Number(localStorage.getItem(PLATE_KEY));

--- a/web/creator/neural.js
+++ b/web/creator/neural.js
@@ -173,10 +173,12 @@ const shown = (key, value) => (key === "scale" ? `×${value}` : Number(value).to
  * @param {number} spec.value
  * @param {{min:number, max:number, step:number, default:number}} spec.range
  * @param {(next:number) => void} spec.onChange  while it is being dragged
+ * @param {() => number} [spec.reset]  the owner's current default, read on reset
  * @param {string} [spec.note]     the tooltip, already in English
  * @param {string} [spec.key]      which dial, for how the number reads
  */
-export function neuralDial({ label, value, range, onChange, note = "", key = "" }) {
+export function neuralDial({ label, value, range, onChange, reset = () => range.default,
+                             note = "", key = "" }) {
   const readout = el("span", { class: "mmc-nr-value", text: shown(key, value) });
   const slider = el("input", {
     type: "range", class: "mmc-nr-range",
@@ -192,9 +194,10 @@ export function neuralDial({ label, value, range, onChange, note = "", key = "" 
     // or a memory of which number it started at.
     ondblclick: (event) => {
       event.preventDefault();
-      event.target.value = String(range.default);
-      readout.textContent = shown(key, range.default);
-      onChange(range.default);
+      const next = reset();
+      event.target.value = String(next);
+      readout.textContent = shown(key, next);
+      onChange(next);
     },
   });
   return el("div", { class: "mmc-nr-dial", title: note ? t(note) : null }, [
@@ -282,6 +285,9 @@ export function neuralRail({ block, onChange, redraw = null, still = false, rang
     rows.push(neuralDial({
       key, label: labels[key], value: Number(block[key]), range: ranges[key],
       note: DIAL_NOTES[key],
+      // Bounds are shared, but Natural's opening detail differs. Read the
+      // active profile at the gesture, even if this rail has not been rebuilt.
+      reset: () => neuralDefaultsFor(block.profile)[key],
       onChange: (next) => { block[key] = next; onChange(); },
     }));
   }

--- a/web/creator/settings.js
+++ b/web/creator/settings.js
@@ -27,7 +27,7 @@ import { loadSettings, saveSettings, resetSettings, noteSettings, loadLatentCach
 import * as P from "./presets.js";
 import { resetSettings as resetRefiner, settingsStored as refinerStored,
          remoteStatus, saveRemote } from "./refine.js";
-import { forgetLayout } from "./fullscreen.js";
+import { forgetLayout, layoutPrefsHeld } from "./fullscreen.js";
 import { t } from "./i18n.js";
 import { CLOCK_TOKENS, FRAME_TOKENS, cleanPrefix, folderOf, stemOf, examplePath,
          splitTokens, tokenLabel, tokenValues } from "./outputs.js";
@@ -503,7 +503,7 @@ class SettingsPage {
     ]);
     this.kept = {
       presets,
-      picker,
+      picker: picker + layoutPrefsHeld(),
       loras,
       refiner: refinerStored(),
       cacheBytes: Number(this.cache?.bytes ?? 0),


### PR DESCRIPTION
Related to #54, items 16 and 18. These are lower-severity UI corrections, separate from rendering blockers.

## Changes and rationale

- **`web/creator/neural.js`**: double-click reset reads the active profile's default rather than the shared slider range's default. In particular, Natural's opening detail value is no longer reset to the wrong profile's value. Slider bounds remain unchanged.
- **`web/creator/api.js`**: include remembered picker folders in stored-record counts even when the favorites list is empty.
- **`web/creator/fullscreen.js`, `web/creator/settings.js`**: count the same remembered view/scale keys that the existing removal action deletes, so those controls remain available when only layout preferences exist.

## Validation

`test_neural_profile_reset.py` covers four profiles × four dials and profile changes while the rail is open. `test_picker_inventory.py` covers folder-only, view-only, scale-only, mixed and empty records, individual/full clearing, and preservation of unrelated keys.

**Boundary:** frontend fixtures with in-memory storage. No actual user preferences were cleared, and these changes do not alter image/video generation.
