### PR TITLE
Attach queued takes only to their original cards

### DIFF
--- a/creator/compile.py
+++ b/creator/compile.py
@@ -3074,7 +3074,9 @@ def _chained_request(data, segment, pool, global_prompt, cast=()):
     #   errors and announcements can name the card. It only exists on a render
     #   that holds something back, so leaving it in meant every card of a
     #   part-render missed the cache the whole render had just filled.
-    for key in ("seed", "take", "hold", "card_no"):
+    # - `card_id` is persistent UI ownership for queued takes, not a model
+    #   input. Assigning/recovering an identity must not re-encode a shot.
+    for key in ("seed", "take", "hold", "card_no", "card_id"):
         request.pop(key, None)
     request["prompt"] = _join_prompt(global_prompt, segment.get("prompt"))
     # A shot-scoped rewrite gets the same join: it stands in for the

--- a/tests/test_take_card_cache.py
+++ b/tests/test_take_card_cache.py
@@ -1,0 +1,48 @@
+"""UI card identities never become generation conditioning cache inputs.
+
+    python tests/test_take_card_cache.py
+"""
+
+import copy
+import unittest
+
+import layout
+
+compiler = layout.load("compile", package="take_card_cache_tests").compile
+
+
+class TakeCardCache(unittest.TestCase):
+    def test_ids_are_not_part_of_any_timeline_payload(self):
+        for family in ("h3", "ltx25"):
+            for mode in ("chained", "merged", "single", "clip", "held"):
+                with self.subTest(family=family, mode=mode):
+                    piece = {"family": family, "render": "chained", "prompt": "one piece",
+                             "aspect": "16:9", "short_edge": 480,
+                             "segments": [
+                                 {"prompt": "first", "duration_s": 5, "assets": [], "loras": []},
+                                 {"prompt": "second", "duration_s": 5, "assets": [], "loras": []},
+                             ]}
+                    if mode == "merged":
+                        piece["segments"][1]["merge"] = True
+                    elif mode == "single":
+                        piece["render"] = "single"
+                    elif mode == "clip":
+                        piece["segments"][0] = {"kind": "clip", "filename": "footage.mp4",
+                                                "duration_s": 5, "width": 832, "height": 480}
+                    elif mode == "held":
+                        piece["segments"][0].update(hold=True, take={
+                            "filename": "held.mp4 [output]", "duration_s": 5,
+                            "width": 832, "height": 480, "has_audio": True,
+                        })
+                    identified = copy.deepcopy(piece)
+                    for n, segment in enumerate(identified["segments"]):
+                        segment["card_id"] = f"ui-only-{n}"
+                    # This is the byte-bearing payload put into each family
+                    # segment node, not merely the prompt text after parsing.
+                    plain = compiler.timeline_payloads(compiler.rendered_piece(piece))
+                    with_ids = compiler.timeline_payloads(compiler.rendered_piece(identified))
+                    self.assertEqual(plain, with_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_takes_identity.py
+++ b/tests/test_takes_identity.py
@@ -7,10 +7,10 @@ queued*. The strip is editable while a render runs, so by the time the take
 arrives that number may point at another card: a move swaps two, a removal
 slides every later card up one. `attachTakes` used to read the number against
 the current strip and pin the take on whoever sat there, stamped so that the
-"edited since" mark stayed quiet. It now reads it against the snapshot the
-timeline body takes on `promptQueued` — the card objects in queue order — and a
-card that was removed keeps its take in the history rather than handing it to a
-neighbour.
+"edited since" mark stayed quiet. It now reads it against the submitted graph
+paired with its accepted prompt id, using persistent card identities in queue
+order. A removed card keeps its take in history rather than handing it to a
+neighbour, even one with an identical prompt.
 
 The same number game, on the piece's aspect source: it names a card, and it
 follows that card through a move, a copy and a removal the way a seam's source
@@ -62,8 +62,8 @@ const out = {};
   out.removed = { takes: takes(t), prompts: t.segments.map((seg) => seg.prompt), landed };
 }
 
-// The body rebuilt from the widget between queue and report: no object survives,
-// so the stamp decides — an unchanged strip lands by number, an edited card does not.
+// The body rebuilt from the widget: persistent identity survives, including an
+// edited card. Its queued stamp still marks that take as needing another look.
 {
   const t = strip();
   const queued = s.queuedCards(t);
@@ -74,6 +74,7 @@ const out = {};
   edited.segments[1].prompt = "shot b, rewritten";
   s.attachTakes(edited, [report(1), report(2), report(3)], queued);
   out.edited = takes(edited);
+  out.editedMarks = [...s.editedSince(edited)];
 }
 
 // No snapshot at all — a page that loaded mid-render — is the old behaviour.
@@ -116,8 +117,9 @@ check("a moved card keeps its own take",
 check("a removed card's take goes to nobody",
       got["removed"], {"takes": ["s2", "s3"], "prompts": ["shot b", "shot c"],
                        "landed": True})
-check("a rebuilt but unchanged strip lands by number", got["rebuilt"], ["s1", "s2", "s3"])
-check("...and a card edited in the rebuilt strip is skipped", got["edited"], ["s1", None, "s3"])
+check("a rebuilt strip keeps its identities", got["rebuilt"], ["s1", "s2", "s3"])
+check("...and an edited card keeps its own take", got["edited"], ["s1", "s2", "s3"])
+check("...but that take is marked stale", got["editedMarks"], [1])
 check("no snapshot is the old behaviour", got["bare"], [None, "s2", None])
 check("a card edited while its own render ran is marked", got["markedDuring"], [0])
 check("the aspect source follows a moved card", got["aspectMoved"], 3)

--- a/tests/test_takes_queue.py
+++ b/tests/test_takes_queue.py
@@ -1,0 +1,307 @@
+"""Queue ownership under identical cards, overlapping submissions and reloads.
+
+    python tests/test_takes_queue.py
+
+Actual state/TimelineBody/Stage/queue methods, a small DOM and a mocked ComfyUI
+transport. The transport matches api.queuePrompt(number, {output, workflow})
+and its {prompt_id} response; promptQueued has no server id to correlate.
+"""
+
+import layout
+from domshim import DOM
+from harness import check, passed
+
+layout.skip_without_node()
+
+SCRIPT = r"""
+const { strict: assert } = await import('node:assert');
+const { api } = await import('../scripts/api.js');
+const originalFetch = api.fetchApi;
+let history = {}, running = [], deferredHistory = null;
+api.fetchApi = async (url, ...args) => {
+  if (url.startsWith('/history/')) {
+    if (deferredHistory) return await deferredHistory;
+    return {ok:true, json:async()=>history};
+  }
+  if (url === '/queue') return {ok:true, json:async()=>({queue_running:running,queue_pending:[]})};
+  return originalFetch.call(api, url, ...args);
+};
+const events = new Map();
+api.addEventListener = (name, fn) => {
+  if (!events.has(name)) events.set(name, new Set());
+  events.get(name).add(fn);
+};
+api.removeEventListener = (name, fn) => events.get(name)?.delete(fn);
+const say = (name, detail) => { for (const fn of events.get(name) ?? []) fn({type:name,detail}); };
+const requests = [];
+api.queuePrompt = function(...args) {
+  return new Promise((resolve,reject)=>requests.push({args,resolve,reject,receiver:this}));
+};
+const S = await import('./web/creator/state.js');
+const { TimelineBody } = await import('./web/creator/timeline.js');
+// Layout/model catalog painting is not the ownership contract. The real
+// constructor, commit serialization, Stage, API hook and take methods run.
+TimelineBody.prototype.render = function() {};
+TimelineBody.prototype.adoptWeights = function() {};
+const bodies = [];
+const make = (names=['A','B'], id='11', initial=null, type='MiniMaxH3Creator', widgets={}) => {
+  let blob = initial ?? JSON.stringify({version:2,prompt:'piece',segments:names.map(prompt=>({prompt,duration_s:5,assets:[],loras:[]}))});
+  const body = new TimelineBody({read:()=>blob,write:value=>{blob=value;},nodeId:()=>id,widgets});
+  body.testNodeType = type;
+  bodies.push(body);
+  return body;
+};
+const outputOf = (...bodies) => Object.fromEntries(bodies.map(body=>[
+  String(body.nodeId()),{class_type:body.testNodeType,inputs:{
+    [body.testNodeType === 'MiniMaxH3Creator' ? 'creator_data' : 'timeline_data']:body.read()
+  }}
+]));
+const report = (segment,filename) => ({segment,filename,duration_s:5});
+const names = body => body.timeline.segments.map(card=>card.take?.filename ?? null);
+const queue = async (body,id,output=outputOf(body)) => {
+  const pending = api.queuePrompt(0,{output,workflow:{}});
+  requests.at(-1).resolve({prompt_id:id});
+  await pending;
+  say('promptQueued',{number:0,batchCount:1,requestId:requests.length});
+  return output;
+};
+const deliver = (body,id,reports) => say('executed',{
+  display_node:String(body.nodeId()),prompt_id:id,output:{mmc_takes:reports}
+});
+
+// Content equality is never live ownership, even after the old owner vanished.
+{
+  const body=make(['same','same']);
+  await queue(body,'identical');
+  body.timeline.segments.splice(0,1); body.commit();
+  deliver(body,'identical',[report(1,'deleted.mp4')]);
+  assert.deepEqual(names(body),[null]);
+  deliver(body,'identical',[report(2,'survivor.mp4')]);
+  assert.deepEqual(names(body),['survivor.mp4 [output]']);
+  body.destroy();
+}
+{
+  const body=make(['same']);
+  await queue(body,'clone');
+  const original=body.timeline.segments[0];
+  const copy=S.cloneSegment(original);
+  assert.notEqual(copy.card_id, original.card_id);
+  body.timeline.segments=[copy]; body.commit();
+  deliver(body,'clone',[report(1,'original.mp4')]);
+  assert.deepEqual(names(body),[null]);
+  body.destroy();
+}
+
+// Replies arrive in reverse order; each still owns its submitted strip, not
+// the last promptQueued event or the strip after afterQueued advanced widgets.
+{
+  const body=make();
+  const first=api.queuePrompt(0,{output:outputOf(body),workflow:{}});
+  const request1=requests.at(-1);
+  body.timeline.segments.reverse(); body.commit();
+  const second=api.queuePrompt(0,{output:outputOf(body),workflow:{}});
+  requests.at(-1).resolve({prompt_id:'second'});
+  request1.resolve({prompt_id:'first'});
+  await Promise.all([first,second]);
+  say('promptQueued',{number:0,batchCount:2,requestId:42});
+  deliver(body,'first',[report(1,'first-A.mp4'),report(2,'first-B.mp4')]);
+  assert.deepEqual(names(body),['first-B.mp4 [output]','first-A.mp4 [output]']);
+  deliver(body,'second',[report(1,'second-B.mp4'),report(2,'second-A.mp4')]);
+  assert.deepEqual(names(body),['second-B.mp4 [output]','second-A.mp4 [output]']);
+  assert.equal(request1.receiver,api);
+  body.destroy();
+}
+
+// A serialized prompt can already differ from the live UI when it is posted.
+{
+  const body=make(['submitted']);
+  const output=outputOf(body);
+  body.timeline.segments[0].prompt='edited after graph serialization'; body.commit();
+  await queue(body,'serialized',output);
+  body.reload(); // New objects, same persisted identities.
+  deliver(body,'serialized',[report(1,'submitted.mp4')]);
+  assert.deepEqual(names(body),['submitted.mp4 [output]']);
+  assert.deepEqual([...S.editedSince(body.timeline)],[0]);
+  body.destroy();
+}
+
+// Multiple Creator nodes in one graph retain separate snapshots and reports.
+{
+  const a=make(['A'],'11'), b=make(['B'],'22',null,'MiniMaxH3Timeline');
+  await queue(a,'two-nodes',outputOf(a,b));
+  deliver(b,'two-nodes',[report(1,'B.mp4')]);
+  assert.deepEqual(names(a),[null]);
+  assert.deepEqual(names(b),['B.mp4 [output]']);
+  deliver(a,'two-nodes',[report(1,'A.mp4')]);
+  assert.deepEqual(names(a),['A.mp4 [output]']);
+  a.destroy();b.destroy();
+}
+
+// A take may arrive before the HTTP response. /queue is the authoritative
+// submitted graph; accepting the response later cannot replace its identity.
+{
+  const body=make(['fast']);
+  const output=outputOf(body);
+  const pending=api.queuePrompt(0,{output,workflow:{}});
+  running=[[0,'fast',output,{},[]]];
+  await body.takeTakes([report(1,'fast.mp4')],{promptId:'fast'});
+  assert.deepEqual(names(body),['fast.mp4 [output]']);
+  requests.at(-1).resolve({prompt_id:'fast'});await pending;
+  running=[];body.destroy();
+}
+
+// After reload, history carries both the prompt id and its original graph.
+{
+  const old=make(['reload']);
+  const output=outputOf(old), blob=old.read();old.destroy();
+  const body=make([], '11', blob);
+  body.timeline.segments[0].prompt='edited after reload';body.commit();
+  history={recovered:{prompt:[0,'recovered',output,{},[]],outputs:{
+    '11.take':{mmc_takes:[report(1,'recovered.mp4')]},
+    '11.save':{mmc_video:[{filename:'whole.mp4',type:'output'}]}
+  }}};
+  const tasks=[];
+  body.stage.onTakes=(reports,context)=>{const task=body.takeTakes(reports,context);tasks.push(task);return task;};
+  body.stage.promptId='recovered';body.stage.state='sampling';
+  await body.stage.probe();await Promise.all(tasks);
+  assert.deepEqual(names(body),['recovered.mp4 [output]']);
+  assert.deepEqual([...S.editedSince(body.timeline)],[0]);
+  assert.equal(body.stage.state,'done');history={};body.destroy();
+}
+
+// Unknown prompt/node ownership is left in history, never attached by number.
+{
+  const body=make(['unknown']);
+  await body.takeTakes([report(1,'unknown.mp4')],{promptId:'unknown'});
+  assert.deepEqual(names(body),[null]);
+  const pending=api.queuePrompt(0,{output:outputOf(body),workflow:{}});
+  requests.at(-1).reject(new Error('refused'));
+  await assert.rejects(pending,/refused/);
+  assert.equal(body.queued.size,0);
+  body.destroy();
+}
+
+// An in-flight recovery response for job 1 cannot land after job 2 started.
+{
+  const body=make(['probe']);let resolve;
+  deferredHistory=new Promise(done=>{resolve=done;});
+  body.stage.promptId='old';body.stage.state='sampling';
+  const pending=body.stage.probe();
+  say('execution_start',{prompt_id:'new'});
+  resolve({ok:true,json:async()=>({old:{prompt:[0,'old',outputOf(body)],outputs:{
+    '11.save':{mmc_video:[{filename:'old.mp4'}],mmc_takes:[report(1,'old.mp4')]}
+  }}})});
+  await pending;
+  assert.deepEqual(names(body),[null]);
+  assert.equal(body.stage.result,null);
+  deferredHistory=null;body.destroy();
+}
+
+// Frontend identity is excluded from render stamps; cloning has the same
+// content stamp but different ownership. Only explicit, unique legacy
+// history reconstruction may use content, never a live snapshot.
+{
+  const strip=S.parseTimeline(JSON.stringify({segments:[{prompt:'a'},{prompt:'b'}]}));
+  const queued=S.queuedCards(strip);
+  const copy=S.parseTimeline(S.serializeTimeline(strip));
+  copy.segments.forEach(card=>{delete card.card_id;});S.ensureCardIds(copy);
+  assert.deepEqual(S.queuedCards(copy).stamps,queued.stamps);
+  S.attachTakes(copy,[report(1,'legacy.mp4')],{...queued,legacy:true});
+  assert.equal(copy.segments[0].take.filename,'legacy.mp4 [output]');
+  const ambiguous=S.parseTimeline(JSON.stringify({segments:[{prompt:'same'},{prompt:'same'}]}));
+  const prior=S.queuedCards(ambiguous,{legacy:true});
+  ambiguous.segments.forEach(card=>{delete card.card_id;});S.ensureCardIds(ambiguous);
+  assert.equal(S.attachTakes(ambiguous,[report(1,'ambiguous.mp4')],prior),false);
+}
+
+// An id-only migration cannot pre-fill default sampling and prevent the
+// existing legacy-widget adoption. Version-1 Creator data keeps its id too.
+{
+  const body=make([], '11', JSON.stringify({version:1,prompt:'legacy shot',duration_s:5}),
+    'MiniMaxH3Creator',{steps:{value:19},cfg:{value:2.5}});
+  const raw=JSON.parse(body.read());
+  assert.equal(raw.sampling,undefined);
+  assert.ok(raw.card_id);
+  await queue(body,'version-one');
+  body.reload();
+  const adopted=JSON.parse(body.read());
+  assert.equal(adopted.sampling.steps,19);
+  assert.equal(adopted.sampling.cfg,2.5);
+  assert.equal(adopted.segments[0].card_id,raw.card_id);
+  deliver(body,'version-one',[report(1,'legacy.mp4')]);
+  assert.deepEqual(names(body),['legacy.mp4 [output]']);
+  body.destroy();
+}
+
+// One legacy card without an id does not weaken another card's known id.
+{
+  const raw=JSON.stringify({version:2,prompt:'piece',segments:[
+    {card_id:'known-original',prompt:'A',duration_s:5}, {prompt:'B',duration_s:5}
+  ]});
+  const body=make([], '11', raw);
+  body.timeline.segments[0]=S.cloneSegment(body.timeline.segments[0]);body.commit();
+  const output={'11':{class_type:'MiniMaxH3Creator',inputs:{creator_data:raw}}};
+  await body.takeTakes([report(1,'removed-known.mp4'),report(2,'legacy-B.mp4')],
+    {promptId:'mixed',prompt:[0,'mixed',output]});
+  assert.deepEqual(names(body),[null,'legacy-B.mp4 [output]']);
+  body.destroy();
+}
+
+// Recovery for an older report may complete after a newer report has already
+// landed. Only that card's older take is refused; no global "last request wins".
+{
+  const body=make(['one']);const output=outputOf(body);let resolve;
+  deferredHistory=new Promise(done=>{resolve=done;});
+  const older=body.takeTakes([report(1,'older.mp4')],{promptId:'slow-history'});
+  await queue(body,'newer-direct');
+  deliver(body,'newer-direct',[report(1,'newer.mp4')]);
+  resolve({ok:true,json:async()=>({'slow-history':{prompt:[0,'slow-history',output]}})});
+  await older;
+  assert.deepEqual(names(body),['newer.mp4 [output]']);
+  deferredHistory=null;body.destroy();
+}
+
+// The shared wrapper is transparent to partial-queue options and response
+// identity, and it cannot write back into a body destroyed during the request.
+{
+  const body=make(['destroyed']);const options={partialExecutionTargets:['11']};
+  const pending=api.queuePrompt(-1,{output:outputOf(body),workflow:{}},options);
+  const request=requests.at(-1), answer={prompt_id:'destroyed',node_errors:{}};
+  body.destroy();request.resolve(answer);
+  assert.equal(await pending,answer);
+  assert.equal(request.receiver,api);
+  assert.equal(request.args[0],-1);
+  assert.equal(request.args[2],options);
+  assert.equal(body.queued.size,0);
+}
+
+// Corrupt or not-yet-assigned widget values retain parseTimeline's safe default
+// fallback, rather than a migration throwing before the node can be opened.
+{
+  for (const raw of ['', '{broken', 'null', '42', 'true', '[]', '"text"']) {
+    const fallback=S.parseTimeline(raw);
+    const body=make([], '11', raw);
+    assert.equal(body.timeline.segments.length,fallback.segments.length);
+    assert.deepEqual(S.queuedCards(body.timeline).stamps,S.queuedCards(fallback).stamps);
+    assert.equal(body.read(),raw);
+    body.destroy();
+  }
+  let reads=0,writes=0;
+  const body=new TimelineBody({nodeId:()=>11,
+    read:()=>++reads === 1 ? '{"segments":[{"prompt":"a"}]}' : '',
+    write:()=>{writes++;}});
+  assert.equal(writes,0);
+  body.destroy();
+  const writeError=new Error('widget write failed');
+  assert.throws(()=>new TimelineBody({nodeId:()=>11,
+    read:()=>'{"segments":[{"prompt":"a"}]}',
+    write:()=>{throw writeError;}}),error=>error===writeError);
+}
+for(const body of bodies) body.destroy();
+console.log(JSON.stringify({passed:true,scenarios:16}));
+"""
+
+with layout.pack() as packed:
+    result = layout.in_pack(DOM + SCRIPT, packed)
+check("prompt-scoped take ownership scenarios", result, {"passed": True, "scenarios": 16})
+passed("take identities, submitted prompts and history recovery stay paired")

--- a/web/creator/queue.js
+++ b/web/creator/queue.js
@@ -16,6 +16,63 @@ import { t } from "./i18n.js";
 
 const listeners = new Set();
 
+// promptQueued is a batch notification ({number, batchCount, requestId}) in
+// ComfyUI's frontend, not a server prompt id. Observe the actual submission
+// boundary once so each accepted prompt is paired with the graph it sent,
+// including batches and replies that arrive after an execution event.
+const submissions = new Set();
+let observingSubmissions = false;
+
+export function watchSubmittedPrompts(capture, accepted) {
+  if (!observingSubmissions && typeof api.queuePrompt === "function") {
+    const original = api.queuePrompt;
+    api.queuePrompt = async function (...args) {
+      const snapshots = [];
+      for (const listener of submissions) {
+        try {
+          const snapshot = listener.capture(args[1]?.output);
+          if (snapshot) snapshots.push([listener, snapshot]);
+        } catch (error) { console.warn("[Continuity] could not snapshot a submitted strip", error); }
+      }
+      // Preserve the API's arguments, receiver, result and rejection. A failed
+      // request must not create a queue entry or attach somebody else's take.
+      const answer = await original.apply(this, args);
+      if (answer?.prompt_id) {
+        for (const [listener, snapshot] of snapshots) {
+          if (!submissions.has(listener)) continue;
+          try { listener.accepted(String(answer.prompt_id), snapshot); }
+          catch (error) { console.warn("[Continuity] could not record a submitted strip", error); }
+        }
+      }
+      return answer;
+    };
+    observingSubmissions = true;
+  }
+  const listener = { capture, accepted };
+  submissions.add(listener);
+  return () => submissions.delete(listener);
+}
+
+/** Recover the submitted graph after a page reload, never the current graph.
+ * A running prompt lives in /queue; a completed/failed one lives in history. */
+export async function submittedPrompt(promptId) {
+  const id = String(promptId);
+  const history = await api.fetchApi(`/history/${encodeURIComponent(id)}`);
+  if (history.ok) {
+    const entry = (await history.json())?.[id];
+    if (entry?.prompt?.[2]) return entry.prompt[2];
+  }
+  const response = await api.fetchApi("/queue");
+  if (!response.ok) return null;
+  const queue = await response.json();
+  const entry = [...(queue.queue_running ?? []), ...(queue.queue_pending ?? [])]
+    .find((item) => String(item?.[1]) === id);
+  if (entry?.[2]) return entry[2];
+  // The render may have left the queue between those two reads.
+  const finished = await api.fetchApi(`/history/${encodeURIComponent(id)}`);
+  return finished.ok ? (await finished.json())?.[id]?.prompt?.[2] ?? null : null;
+}
+
 // `remaining` is ComfyUI's own `queue_remaining`: everything queued including
 // whatever is on the sampler right now. `running` is whether execution has
 // actually started on one, which is the difference between "yours is next" and

--- a/web/creator/stage.js
+++ b/web/creator/stage.js
@@ -380,7 +380,7 @@ export class Stage {
         // render coming back even though the node that made it is not on the
         // canvas.
         if (String(detail.display_node) !== String(this.nodeId())) break;
-        this.finish(detail.output);
+        this.finish(detail.output, { promptId: detail.prompt_id ?? this.promptId });
         break;
 
       case "mmc_segment":
@@ -479,13 +479,13 @@ export class Stage {
    * `MiniMaxH3SaveImage` reports `mmc_image` instead; which one arrives is also
    * what says whether the result is a clip or a still.
    */
-  finish(output) {
+  finish(output, { promptId = this.promptId, prompt = null } = {}) {
     // The passes, each as its own file, so a card whose pass came out right
     // never has to be sampled again. Before the `saved` gate: most takes now
     // arrive one at a time from `ContinuityTake` while the render is still
     // running — an executed message with a take and no piece in it — and the
     // rest still ride the save node's report the way they always did.
-    if (output?.mmc_takes?.length) this.onTakes?.(output.mmc_takes);
+    if (output?.mmc_takes?.length) this.onTakes?.(output.mmc_takes, { promptId, prompt });
     const saved = output?.mmc_video?.[0] ?? output?.mmc_image?.[0];
     if (!saved) return;
     this.state = "done";
@@ -551,14 +551,15 @@ export class Stage {
     if (Date.now() - this.probedAt < PROBE_EVERY_MS) return;
     this.probing = true;
     this.probedAt = Date.now();
+    const promptId = this.promptId;
     try {
-      const response = await api.fetchApi(`/history/${encodeURIComponent(this.promptId)}`);
+      const response = await api.fetchApi(`/history/${encodeURIComponent(promptId)}`);
       if (!response.ok) return;
-      const entry = (await response.json())?.[this.promptId];
+      const entry = (await response.json())?.[promptId];
       // The stage may have caught up on its own while this was in flight — the
       // wire coming back mid-probe is the likeliest moment of all — and a probe
       // must never overwrite a result that arrived the ordinary way.
-      if (this.state !== "sampling") return;
+      if (this.state !== "sampling" || this.promptId !== promptId) return;
       if (!entry) return;
       // The takes first, wherever the entry holds them: `ContinuityTake`
       // reports them one node at a time, so they are scattered across the
@@ -566,10 +567,10 @@ export class Stage {
       // is the case this exists for — the passes that landed before the
       // failure are exactly the ones worth keeping.
       const takes = this.takesOf(entry.outputs, entry.meta);
-      if (takes.length) this.onTakes?.(takes);
+      if (takes.length) this.onTakes?.(takes, { promptId, prompt: entry.prompt });
       const output = this.savedOutput(entry.outputs, entry.meta);
       if (output) {
-        this.finish(output);
+        this.finish(output, { promptId, prompt: entry.prompt });
         return;
       }
       // In history, with nothing of ours in it: the render failed or was

--- a/web/creator/state.js
+++ b/web/creator/state.js
@@ -1924,22 +1924,17 @@ export function segmentSeed(segment) {
 /**
  * The takes a finished render reported, onto the cards that made them.
  *
- * -> whether any landed. By card number rather than by position, because a
- * render is not always the whole strip: the save node is told which card each
- * pass is, and that number is the number on the card. One that has moved or
- * been deleted since the queue went out is left alone rather than guessed at.
+ * -> whether any landed. Report numbers address the submitted snapshot, not
+ * the live strip. Its persistent card ids survive reloads/reorders; a removed
+ * card's result remains in history rather than landing on an identical copy.
  *
  * Nothing is held here. A take that came back is a take to look at, and holding
  * the card is the gesture that says it is good — doing it here would decide for
  * the user, and would quietly stop the next queue from re-rendering the card
  * they were about to re-render.
  *
- * `stamp` is what the card looked like when its take was attached, so an edit
- * afterwards can be marked rather than silently shipped — see `editedSince`. It
- * is taken now rather than at queue time, which leaves a window: a card edited
- * while its own render was still running is stamped as if the edit had been in
- * it. The cost of closing that is a queue-time hook, for a mark that only ever
- * says "look at this again".
+ * `stamp` comes from that same submitted snapshot, so edits made while the
+ * render ran are marked by `editedSince` rather than silently approved.
  */
 export function attachTakes(timeline, reports, queued = null) {
   // One serialization for the whole report rather than one per take: the strip
@@ -1961,35 +1956,55 @@ export function attachTakes(timeline, reports, queued = null) {
 }
 
 /**
- * The strip as it went out: the card objects in queue order and each one's
- * stamp. Taken on `promptQueued` by the timeline body, and what `attachTakes`
- * reads a report's card number against — the number is the card's position
- * *then*, and a card moved or removed while the render ran is not the card
- * now at that position (issue #47).
+ * The strip as submitted: card identities in queue order and render stamps.
+ * `legacy` is only for explicit recovery of an old saved prompt without ids;
+ * a live snapshot never falls back to identical content after deletion.
  */
-export function queuedCards(timeline) {
-  return { cards: [...timeline.segments], stamps: stampsOf(timeline) };
+export function queuedCards(timeline, { legacy = false } = {}) {
+  ensureCardIds(timeline);
+  return { ids: timeline.segments.map((card) => card.card_id),
+           stamps: stampsOf(timeline), legacy };
 }
 
 /**
  * Where the card that was number `number` at queue time sits now, or -1.
  *
- * By identity first: the strip is edited in place, so a moved card is the
- * same object at another index. Failing that — the body was rebuilt from the
- * widget, say on a reload — by the stamp: the card now at that number is
- * accepted only when it is byte-for-byte the card that was queued there. A
- * card that was removed matches neither and its take is left in the history
- * rather than pinned on whoever slid into its place.
+ * Never infer live identity from equal prompts. Explicit legacy history
+ * recovery permits a positional match only if its stamp is unique in both
+ * strips; ambiguous identical cards remain unattached in history.
  */
 function queuedIndex(timeline, queued, number, stamps) {
-  const card = queued.cards[number - 1];
-  if (card) {
-    const index = timeline.segments.indexOf(card);
+  const id = queued.ids?.[number - 1];
+  if (id) {
+    const index = timeline.segments.findIndex((card) => card.card_id === id);
     if (index >= 0) return index;
   }
   const stamp = queued.stamps[number - 1];
-  if (stamp !== undefined && stamps[number - 1] === stamp) return number - 1;
+  const legacy = Array.isArray(queued.legacy) ? queued.legacy[number - 1] : queued.legacy === true;
+  if (legacy && stamp !== undefined && stamps[number - 1] === stamp
+      && queued.stamps.filter((value) => value === stamp).length === 1
+      && stamps.filter((value) => value === stamp).length === 1) return number - 1;
   return -1;
+}
+
+/** Frontend ownership only: not part of the description the model renders. */
+let nextCardId = 0;
+function newCardId() {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `card-${Date.now().toString(36)}-${++nextCardId}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function ensureCardIds(timeline) {
+  const seen = new Set();
+  let changed = false;
+  for (const card of timeline.segments ?? []) {
+    if (typeof card.card_id !== "string" || !card.card_id || seen.has(card.card_id)) {
+      card.card_id = newCardId();
+      changed = true;
+    }
+    seen.add(card.card_id);
+  }
+  return changed;
 }
 
 function takeFrom(report, stamp) {
@@ -2036,7 +2051,7 @@ function stampsOf(timeline) {
   const { segments, ...piece } = blob;
   const head = JSON.stringify(piece);
   return (segments ?? []).map((card) => {
-    const { hold, take, ...rest } = card;
+    const { hold, take, card_id, ...rest } = card;
     return hash(head + JSON.stringify(rest));
   });
 }
@@ -3037,6 +3052,7 @@ export function parseTimeline(raw) {
           const width = Number(raw.feather);
           if (featherGridOf(timeline).includes(width) && width > 1) segment.feather = width;
           if (raw.feather_pin === true) segment.feather_pin = true;
+          if (typeof raw.card_id === "string") segment.card_id = raw.card_id;
           return segment;
         }
         const segment = parseState(JSON.stringify(raw ?? {}));
@@ -3184,6 +3200,7 @@ export function serializeTimeline(timeline) {
       if (isClip(segment)) {
         return {
           kind: "clip",
+          ...(segment.card_id ? { card_id: segment.card_id } : {}),
           filename: segment.filename,
           duration_s: round2(segment.duration_s),
           ...(segment.width && segment.height
@@ -3205,6 +3222,7 @@ export function serializeTimeline(timeline) {
         };
       }
       const out = serializeCommon(segment, pieceFamily(timeline));
+      if (segment.card_id) out.card_id = segment.card_id;
       // Which pass this segment belongs to, said as "the same one as the
       // segment before me" — so a pass survives inserting, moving and deleting
       // with no numbers to keep in step. Never on the first segment, which is
@@ -3251,7 +3269,10 @@ export function serializeTimeline(timeline) {
 
 /** A copy that shares nothing with the original — for "duplicate segment". */
 export function cloneSegment(segment) {
-  return JSON.parse(JSON.stringify(segment));
+  const copy = JSON.parse(JSON.stringify(segment));
+  // A clone may look identical, but it never owns the original's in-flight take.
+  copy.card_id = newCardId();
+  return copy;
 }
 
 /**

--- a/web/creator/timeline.js
+++ b/web/creator/timeline.js
@@ -28,6 +28,7 @@ import { openAspectPopover, openResolutionPopover, openChoicePopover, facesPill,
 import { refine, refineButton, chosenModel as refineModel } from "./refine.js";
 import { adopted, blobIO, samplingBar } from "./sampling.js";
 import { Stage, stageSource } from "./stage.js";
+import { watchSubmittedPrompts, submittedPrompt } from "./queue.js";
 import { familyPill, weightsPill, loadCatalog, adoptWeights } from "./models.js";
 import * as S from "./state.js";
 import * as Turbo from "./turbo.js";
@@ -2939,6 +2940,28 @@ export class TimelineBody {
     // only decides what a *new* node opens as. So the face grows one.
     this.fullscreen = fullscreen;
     this.timeline = S.parseTimeline(read());
+    // Persist identities before graphToPrompt reads the widget, including
+    // migration of an old strip. They identify UI cards, not render content.
+    if (S.ensureCardIds(this.timeline)) {
+      // Add only ids here. Serializing all defaults before reload() adopts a
+      // legacy node's sampling widgets would overwrite its actual settings.
+      let raw;
+      try { raw = JSON.parse(read()); } catch { raw = null; }
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        let migrated = false;
+        if (Array.isArray(raw.segments)
+            && raw.segments.length === this.timeline.segments.length) {
+          raw.segments = raw.segments.map((card, index) => ({
+            ...card, card_id: this.timeline.segments[index].card_id,
+          }));
+          migrated = true;
+        } else if (!Array.isArray(raw.segments) && this.timeline.segments.length === 1) {
+          raw.card_id = this.timeline.segments[0].card_id;
+          migrated = true;
+        }
+        if (migrated) this.write(JSON.stringify(raw, null, 2));
+      }
+    }
     // The face's editor, when the piece is one shot and the face is wearing
     // one. Null the rest of the time — see `loneShot`.
     this.faceEditor = null;
@@ -2947,13 +2970,13 @@ export class TimelineBody {
     // clip, and what it is making is one picture whatever the strip looks like.
     // attach() floats it beside the node in a Satellite; it never mounts here.
     this.root = el("div", { class: "mmc-root" });
-    // The strip as it went out, for the takes that come back — see
-    // `queuedCards`. `promptQueued` is the frontend's one word on a prompt
-    // leaving, and it is said for every prompt: a snapshot taken on somebody
-    // else's queue is the same strip a moment later, and costs a hash.
-    this.queued = null;
-    this.onQueued = () => { this.queued = S.queuedCards(this.timeline); };
-    api.addEventListener("promptQueued", this.onQueued);
+    this.queued = new Map();
+    this.queueLookups = new Map();
+    this.takeArrivals = new Map();
+    this.takeSequence = 0;
+    this.offSubmitted = watchSubmittedPrompts(
+      (output) => this.submittedCards(output),
+      (promptId, snapshot) => this.rememberQueued(promptId, snapshot));
     this.stage = new Stage({
       nodeId,
       // Which generation the queue is on, said over the preview: the strip runs
@@ -2966,9 +2989,7 @@ export class TimelineBody {
       // Every pass this render wrote, back onto the card that made it. The card
       // is not held by it: what came back is a take, and whether to keep it is
       // the point of looking at it. See `takeTakes`.
-      onTakes: (reported) => {
-        if (S.attachTakes(this.timeline, reported, this.queued)) this.commit();
-      },
+      onTakes: (reported, context) => this.takeTakes(reported, context),
       // View-only: a timeline's references live on its segments, so a pick from
       // here would have no card to land on. The Creator attaches; this browses.
       onGallery: () => openPicker({
@@ -2986,10 +3007,68 @@ export class TimelineBody {
   }
 
   destroy() {
-    api.removeEventListener("promptQueued", this.onQueued);
+    this.destroyed = true;
+    this.offSubmitted?.();
     this.stage?.destroy();
     this.laneFit?.disconnect();
     this.dropFaceEditor();
+  }
+
+  /** Only this node's submitted blob, not the strip currently on screen. */
+  submittedCards(output) {
+    const inputs = output?.[String(this.nodeId())]?.inputs;
+    // The unified Creator and the legacy Timeline mount this same body.
+    const raw = inputs?.creator_data ?? inputs?.timeline_data;
+    if (typeof raw !== "string") return null;
+    try {
+      const parsed = JSON.parse(raw);
+      const cards = S.asPiece(parsed)?.segments;
+      // A mixed old/new blob must not turn off known ownership merely because
+      // a *different* card has no id. Legacy recovery is per submitted slot.
+      const legacy = Array.isArray(cards)
+        ? cards.map((card) => typeof card?.card_id !== "string" || !card.card_id) : false;
+      return S.queuedCards(S.parseTimeline(raw), { legacy });
+    } catch { return null; }
+  }
+
+  rememberQueued(promptId, snapshot) {
+    this.queued.set(String(promptId), snapshot);
+    // Snapshots contain only ids/stamps. Old entries can be recovered from
+    // history if a very large pending batch outlives this bounded notebook.
+    while (this.queued.size > 128) this.queued.delete(this.queued.keys().next().value);
+  }
+
+  async takeTakes(reported, { promptId, prompt = null } = {}) {
+    if (!promptId || this.destroyed) return;
+    const id = String(promptId);
+    const arrival = ++this.takeSequence;
+    let snapshot = this.queued.get(id);
+    if (!snapshot) {
+      if (!this.queueLookups.has(id)) {
+        this.queueLookups.set(id, (async () => {
+          const output = prompt?.[2] ?? await submittedPrompt(id);
+          return this.submittedCards(output);
+        })().catch(() => null));
+      }
+      snapshot = await this.queueLookups.get(id);
+      this.queueLookups.delete(id);
+      snapshot = this.queued.get(id) ?? snapshot;
+      if (!snapshot || this.destroyed) return; // Keep unowned results in history.
+      this.rememberQueued(id, snapshot);
+    }
+    const applicable = reported.filter((report) => {
+      const card = snapshot.ids[Number(report.segment) - 1];
+      if (!card || (this.takeArrivals.get(card) ?? 0) > arrival) return false;
+      // An older history lookup finishing after a newer report must not
+      // overwrite that card's newer take. Other cards may still land normally.
+      this.takeArrivals.set(card, arrival);
+      return true;
+    });
+    if (S.attachTakes(this.timeline, applicable, snapshot)) this.commit();
+    const live = new Set(this.timeline.segments.map((card) => card.card_id));
+    for (const card of this.takeArrivals.keys()) {
+      if (!live.has(card)) this.takeArrivals.delete(card);
+    }
   }
 
   /** See `CreatorEditor.adoptWeights` — same rescue, same reason. */
@@ -3008,6 +3087,7 @@ export class TimelineBody {
     const adopted_ = adopted(this.read(), this.widgets, S.parseTimeline, S.serializeTimeline);
     if (adopted_) this.write(adopted_);
     this.timeline = S.parseTimeline(this.read());
+    if (S.ensureCardIds(this.timeline)) this.write(S.serializeTimeline(this.timeline));
     // The face editor closes over the segment object it was handed, and this is
     // a different one. Dropped rather than re-pointed: `render` builds another
     // against whatever the strip now holds.
@@ -3201,6 +3281,7 @@ export class TimelineBody {
 
   commit() {
     S.syncTimeline(this.timeline);
+    S.ensureCardIds(this.timeline);
     // Removing or disabling the turbo LoRA anywhere — the global stack's
     // manager included — is switching turbo off, and the sampler row has to
     // come back before the blob is written with `on` still in it.


### PR DESCRIPTION
Related to #54, item 5, and the remaining queued-take ownership case discussed after #47.

## Problem

The old snapshot was overwritten on a generic `promptQueued` notification, and a missing card could fall back to another card with identical content. Results from different queued runs could therefore be attached to the wrong live card. The installed frontend's `promptQueued` event contains batch/request information, not the server `prompt_id` needed to correlate a result.

## Changes

- **`web/creator/state.js`**: persist card ownership IDs, give clones distinct IDs, preserve them through reload, and exclude them from render stamps. Resolve a report against its submitted snapshot, not today's position or an identical replacement.
- **`web/creator/queue.js`**: observe the actual `api.queuePrompt(number, {output, workflow}, options)` boundary and associate its accepted ID with the graph it sent. Preserve receiver, arguments, result and rejection. Recover missing snapshots from queue/history rather than from the current workflow.
- **`web/creator/timeline.js`**: keep bounded per-prompt/per-node snapshots for both current `creator_data` and legacy `timeline_data` inputs. Attach only owned results; stale asynchronous history lookups cannot overwrite newer arrivals. Destroyed bodies ignore late work.
- **`web/creator/stage.js`**: forward prompt context from executed/history results, and reject a history response if a different job has since started.
- **`creator/compile.py`**: remove `card_id` alongside existing UI-only bookkeeping before emitting a segment request, avoiding needless model-cache invalidation.

Old history without IDs is recovered only when its eligible card has an unambiguous content match. Unknown/ambiguous ownership leaves the file in history rather than guessing. The change never automatically holds a take.

## Validation

The queue/identity regression suites exercise actual state, TimelineBody, Stage and queue methods with a transport matching the installed ComfyUI API. Cases include current/legacy node inputs, identical survivors, cloning/deletion/reordering, multiple nodes/jobs, reversed HTTP replies, fast completion, request rejection, edits/reload, old-history recovery, and late responses. A compiler check verifies identical model payloads with and without UI IDs.

**Boundary:** DOM/transport and compiler regression tests, not GPU rendering or an interactive production queue. This does not address the separately unconfirmed job-collector completion candidate.
