### PR TITLE
Read Kitchen attention options from V3 schemas

### DIFF
--- a/creator/accel.py
+++ b/creator/accel.py
@@ -242,7 +242,19 @@ def _kitchen_kwargs(node):
     raises instead, on the same terms as a missing pack.
     """
     kwargs = node_defaults(node)
-    options = node.INPUT_TYPES()["required"]["attention"][0]
+    declared = node.INPUT_TYPES()["required"]["attention"]
+    options = ()
+    # Legacy nodes put the choices first. V3's INPUT_TYPES shim instead puts
+    # the type name "COMBO" first and the choices in metadata. Reading that
+    # string as choices rejects a supported kernel and reports C/O/M/B/O (#64).
+    if isinstance(declared, (tuple, list)) and declared:
+        if isinstance(declared[0], (tuple, list)):
+            options = declared[0]
+        elif (declared[0] == "COMBO" and len(declared) > 1
+              and isinstance(declared[1], dict)):
+            choices = declared[1].get("options")
+            if isinstance(choices, (tuple, list)):
+                options = choices
     if KITCHEN_OPTION not in options:
         raise ValueError(
             f"This ComfyUI cannot run '{KITCHEN_OPTION}' — '{KITCHEN_NODE}' "

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -197,6 +197,32 @@ class KernelLessKitchen(FakeKitchen):
     BACKENDS = ["pytorch attention"]
 
 
+class FakeKitchenV3(FakeKitchen):
+    """Core's V3 INPUT_TYPES shim after ComfyUI's September 8 migration.
+
+    The first item is now the type name, not the list of available kernels.
+    Keep the legacy fixture too: installations can have either core version.
+    """
+
+    FUNCTION = "EXECUTE_NORMALIZED"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "model": ("MODEL", {}),
+            "attention": ("COMBO", {
+                "default": "pytorch attention", "options": cls.BACKENDS,
+            }),
+        }}
+
+    def EXECUTE_NORMALIZED(self, model, **kwargs):
+        return self.patch(model, **kwargs)
+
+
+class KernelLessKitchenV3(FakeKitchenV3):
+    BACKENDS = ["pytorch attention"]
+
+
 class FakeChunkFFN:
     """`MiniMaxChunkFeedForward.define_schema`, as the registry holds it."""
 
@@ -548,5 +574,55 @@ check("direct_apply is a no-op when off", accel.direct_apply("MODEL", accel.Sett
 # comes back through `[0]`.
 check("direct_apply runs a V3 node through its shim",
       accel.direct_apply("MODEL", accel.Settings(attention="sage"))[:2], ("sage", "MODEL"))
+
+# Kitchen's V3 migration must not turn the type string "COMBO" into a list of
+# letters or mistake its default (pytorch) for the user's requested kernel.
+for kitchen_class in (FakeKitchen, FakeKitchenV3):
+    install()
+    NODES.NODE_CLASS_MAPPINGS[accel.KITCHEN_NODE] = kitchen_class
+    label = kitchen_class.__name__
+    settings = accel.Settings(attention="kitchen")
+    expected = {"attention": accel.KITCHEN_OPTION}
+    check(f"{label} plans the requested kernel", accel.plan(settings),
+          [(accel.KITCHEN_NODE, expected)])
+    graph = FakeGraph()
+    check(f"{label} graph returns the patched model",
+          accel.graph_apply(graph, "MODEL_LINK", settings), f"{accel.KITCHEN_NODE}:0")
+    check(f"{label} graph receives the selected kernel", graph.built,
+          [(accel.KITCHEN_NODE, {"model": "MODEL_LINK", **expected})])
+    check(f"{label} direct path receives the selected kernel",
+          accel.direct_apply("MODEL", settings),
+          ("kitchen", "MODEL", tuple(sorted(expected.items()))))
+
+for kitchen_class in (KernelLessKitchen, KernelLessKitchenV3):
+    install()
+    NODES.NODE_CLASS_MAPPINGS[accel.KITCHEN_NODE] = kitchen_class
+    label = kitchen_class.__name__
+    expect_error(f"{label} still rejects an unavailable kernel",
+                 lambda: accel.plan(accel.Settings(attention="kitchen")),
+                 "offers ['pytorch attention']")
+    check(f"{label} does not prevent default attention", accel.plan(accel.Settings()), [])
+    check(f"{label} does not change sage planning",
+          accel.plan(accel.Settings(attention="sage")), [(accel.SAGE_NODE, {})])
+
+# Missing/malformed options must fail closed, not pass a substring check on a
+# string and let core silently fall back to a different backend.
+class MalformedKitchen(FakeKitchenV3):
+    declared = None
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"model": ("MODEL",), "attention": cls.declared}}
+
+
+for declared in (("COMBO", {}), ("COMBO", {"options": accel.KITCHEN_OPTION}),
+                 ("COMBO", {"options": None}), (accel.KITCHEN_OPTION,),
+                 ("COMBO", {"options": {accel.KITCHEN_OPTION: True}}),
+                 ("STRING", {"options": [accel.KITCHEN_OPTION]}), (), None):
+    install()
+    MalformedKitchen.declared = declared
+    NODES.NODE_CLASS_MAPPINGS[accel.KITCHEN_NODE] = MalformedKitchen
+    expect_error(f"malformed kitchen declaration {declared!r}",
+                 lambda: accel.plan(accel.Settings(attention="kitchen")), "offers []")
 
 passed("all accelerator tests passed")


### PR DESCRIPTION
## Summary

Addresses the **Kitchen option-detection failure** in #64. The separately reported Sage crash is not diagnosed or claimed fixed by this PR.

ComfyUI migrated `ModelAttentionBackend` to the V3 API on **September 8, 2026** in [Comfy-Org/ComfyUI@5bbdf8a](https://github.com/Comfy-Org/ComfyUI/commit/5bbdf8a76678e2c7cfb519a49a9c3a7137fd6280). Its `INPUT_TYPES()` shim now returns:

```python
("COMBO", {
    "default": "pytorch attention",
    "options": ["pytorch attention", "comfy kitchen attention"],
})
```

Continuity read element zero as the option list. That checked the string `"COMBO"` instead of its choices, falsely rejected an available Kitchen backend, and printed `['C', 'O', 'M', 'B', 'O']`.

## Changes

- **`creator/accel.py::_kitchen_kwargs()`:** read both legacy inline choices and V3 `COMBO` metadata. Continue checking the dynamically advertised choices instead of assuming the kernel is available. Invalid option payloads fail closed; strings/dictionaries cannot accidentally pass the membership check.
- **`tests/test_accel.py`:** retain the legacy fixtures and add V3 coverage for planning, graph emission, normalized direct dispatch, supported/unsupported Kitchen, and malformed declarations. Check that default/Sage planning is unaffected.
- A short code comment explains why the two schema formats need separate handling.

No dependency installation, backend fallback, Sage changes, or unrelated fixes are included.

## Validation

- **Before the fix:** the new V3 regression reproduced the exact `C/O/M/B/O` failure.
- **After the fix:** `python -B tests/test_accel.py` passes, including existing accelerator tests.
- An additional CPU-only check used the installed ComfyUI's real V3 schema conversion and `GraphBuilder`, with the availability flag controlled for supported/unsupported cases. It accepted the advertised Kitchen option, emitted the correct graph input, still rejected unavailable Kitchen, and left default attention untouched.
- `git diff --check` passes.

**Not validated:** GPU inference, actual Kitchen kernel execution on the reporter's hardware, or the separate Sage crash. This fixes the reproduced schema-reading blocker; it does not claim that every attention-related failure in #64 is resolved.
